### PR TITLE
Add SSE streaming, extra news sources and Swagger docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TG News Creator
 
-This project provides a simple Node.js server and React client that aggregate worldwide news from several open RSS feeds.
+This project provides a simple Node.js server and React client that aggregate worldwide news from several open RSS feeds. News are streamed to the client in real time via Server Sent Events (SSE).
 
 ## Available Sources
 - BBC
@@ -8,6 +8,16 @@ This project provides a simple Node.js server and React client that aggregate wo
 - Reuters
 - The Guardian
 - Al Jazeera
+- Kyiv Independent
+- Kyiv Post
+- UNIAN
+- Ukrainska Pravda
+- Ukrinform
+- RFE/RL
+- Liga
+- RBC Ukraine
+- Suspilne
+- Hromadske
 
 ## Getting Started
 
@@ -23,7 +33,7 @@ cd ../client && npm install
 ```bash
 npm start --prefix ../server
 ```
-The server listens on **http://localhost:3001** and exposes `/api/news?sources=source1,source2` returning JSON.
+The server listens on **http://localhost:3001** and exposes an SSE endpoint `/api/news?sources=source1,source2` streaming JSON objects. Swagger documentation is available at `/docs`.
 
 ### Run the client
 
@@ -32,4 +42,4 @@ npm run dev --prefix ../client
 ```
 The React UI will open on **http://localhost:3000**.
 
-Select news sources and press **Start** to load headlines.
+Select news sources and press **Start** to start the live stream of headlines.

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -8,4 +8,16 @@
 }
 .news-item {
   margin-top: .5rem;
+  opacity: 0;
+  animation: fade-in .5s forwards;
+}
+
+.news-item img {
+  max-width: 100%;
+  display: block;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import './App.css'
 
 const AVAILABLE_SOURCES = {
@@ -6,22 +6,46 @@ const AVAILABLE_SOURCES = {
   cnn: 'CNN',
   reuters: 'Reuters',
   guardian: 'The Guardian',
-  aljazeera: 'Al Jazeera'
+  aljazeera: 'Al Jazeera',
+  kyivindependent: 'Kyiv Independent',
+  kyivpost: 'Kyiv Post',
+  unian: 'UNIAN',
+  pravda: 'Ukrainska Pravda',
+  ukrinform: 'Ukrinform',
+  rferl: 'RFE/RL',
+  liga: 'Liga',
+  rbc: 'RBC Ukraine',
+  suspilne: 'Suspilne',
+  hromadske: 'Hromadske'
 }
 
 function App() {
   const [selected, setSelected] = useState([])
   const [news, setNews] = useState([])
+  const [es, setEs] = useState(null)
   const toggle = (source) => {
     setSelected(prev => prev.includes(source) ? prev.filter(s => s !== source) : [...prev, source])
   }
-  const start = async () => {
+  const start = () => {
+    if (es) es.close()
     const params = new URLSearchParams()
     params.append('sources', selected.join(','))
-    const res = await fetch(`http://localhost:3001/api/news?${params}`)
-    const data = await res.json()
-    setNews(data)
+    const eventSource = new EventSource(`http://localhost:3001/api/news?${params}`)
+    setEs(eventSource)
+    eventSource.onmessage = (e) => {
+      const item = JSON.parse(e.data)
+      setNews(prev => [item, ...prev])
+    }
+    eventSource.onerror = () => {
+      eventSource.close()
+      setEs(null)
+    }
   }
+  useEffect(() => {
+    return () => {
+      if (es) es.close()
+    }
+  }, [es])
   return (
     <div className="App">
       <h1>News Aggregator</h1>
@@ -36,7 +60,9 @@ function App() {
       <div className="news-list">
         {news.map((item, idx) => (
           <div key={idx} className="news-item">
+            {item.image && <img src={item.image} alt="" />}
             <a href={item.url} target="_blank" rel="noreferrer">{item.title}</a> <span>({item.source})</span>
+            {item.text && <p>{item.text}</p>}
           </div>
         ))}
       </div>

--- a/server/index.js
+++ b/server/index.js
@@ -2,27 +2,74 @@ const express = require('express');
 const axios = require('axios');
 const Parser = require('rss-parser');
 const cors = require('cors');
+const swaggerJsdoc = require('swagger-jsdoc');
+const swaggerUi = require('swagger-ui-express');
 const sources = require('./sources');
 
 const app = express();
-app.use(cors());
+app.use(cors({ origin: '*' }));
 const PORT = process.env.PORT || 3001;
 
+const swaggerSpec = swaggerJsdoc({
+  definition: {
+    openapi: '3.0.0',
+    info: { title: 'News API', version: '1.0.0' },
+    servers: [{ url: `http://localhost:${PORT}` }]
+  },
+  apis: [__filename]
+});
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+/**
+ * @openapi
+ * /api/news:
+ *   get:
+ *     summary: Stream news items via Server-Sent Events
+ *     parameters:
+ *       - in: query
+ *         name: sources
+ *         schema:
+ *           type: string
+ *         description: Comma separated list of source ids
+ *     responses:
+ *       200:
+ *         description: SSE stream of news objects
+ */
 app.get('/api/news', async (req, res) => {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive'
+  });
+  res.flushHeaders();
+
   const selected = req.query.sources ? req.query.sources.split(',') : [];
   const parser = new Parser();
-  let aggregated = [];
-  for (const name of selected) {
-    const source = sources[name];
-    if (!source) continue;
-    try {
-      const items = await source.fetch(axios, parser);
-      aggregated = aggregated.concat(items.map(item => ({ ...item, source: name })));
-    } catch (err) {
-      console.error('Error fetching source', name, err.message);
+  const seen = new Set();
+
+  const sendItems = async () => {
+    for (const name of selected) {
+      const source = sources[name];
+      if (!source) continue;
+      try {
+        const items = await source.fetch(axios, parser);
+        for (const item of items) {
+          if (seen.has(item.url)) continue;
+          seen.add(item.url);
+          res.write(`data: ${JSON.stringify({ ...item, source: name })}\n\n`);
+        }
+      } catch (err) {
+        console.error('Error fetching source', name, err.message);
+      }
     }
-  }
-  res.json(aggregated);
+  };
+
+  await sendItems();
+  const interval = setInterval(sendItems, 60000);
+  req.on('close', () => {
+    clearInterval(interval);
+  });
 });
 
 app.listen(PORT, () => {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,8 +12,73 @@
         "axios": "^1.9.0",
         "cors": "^2.8.5",
         "express": "^5.1.0",
-        "rss-parser": "^3.13.0"
+        "rss-parser": "^3.13.0",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -27,6 +92,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -44,6 +115,12 @@
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.0",
@@ -63,6 +140,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/bytes": {
@@ -103,6 +190,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -114,6 +207,21 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -200,6 +308,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dunder-proto": {
@@ -290,6 +410,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -433,6 +562,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -477,6 +612,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gopd": {
@@ -558,6 +714,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -577,6 +744,38 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -628,6 +827,18 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -687,6 +898,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -694,6 +912,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -945,6 +1172,62 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.22.0.tgz",
+      "integrity": "sha512-8YlCSxiyb8uPFa7qoB1lRHYr1PBbT1NuV9RvQdFFPFPudRBTPf9coU5jl02KhzvrtmTEw4jXRgb0kg8pJvVuWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -975,6 +1258,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {
@@ -1012,6 +1304,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/server/package.json
+++ b/server/package.json
@@ -16,5 +16,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "rss-parser": "^3.13.0"
+    ,"swagger-jsdoc": "^6.2.8"
+    ,"swagger-ui-express": "^5.0.1"
   }
 }

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -3,35 +3,195 @@ module.exports = {
     label: 'BBC',
     fetch: async (axios, parser) => {
       const feed = await parser.parseURL('http://feeds.bbci.co.uk/news/world/rss.xml');
-      return feed.items.map(i => ({ title: i.title, url: i.link, publishedAt: i.pubDate }));
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
     }
   },
   cnn: {
     label: 'CNN',
     fetch: async (axios, parser) => {
       const feed = await parser.parseURL('http://rss.cnn.com/rss/cnn_world.rss');
-      return feed.items.map(i => ({ title: i.title, url: i.link, publishedAt: i.pubDate }));
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
     }
   },
   reuters: {
     label: 'Reuters',
     fetch: async (axios, parser) => {
-      const feed = await parser.parseURL('http://feeds.reuters.com/Reuters/worldNews');
-      return feed.items.map(i => ({ title: i.title, url: i.link, publishedAt: i.pubDate }));
+      const feed = await parser.parseURL('https://news.google.com/rss/search?q=Reuters&hl=en-US&gl=US&ceid=US:en');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
     }
   },
   guardian: {
     label: 'The Guardian',
     fetch: async (axios, parser) => {
       const feed = await parser.parseURL('https://www.theguardian.com/world/rss');
-      return feed.items.map(i => ({ title: i.title, url: i.link, publishedAt: i.pubDate }));
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
     }
   },
   aljazeera: {
     label: 'Al Jazeera',
     fetch: async (axios, parser) => {
       const feed = await parser.parseURL('https://www.aljazeera.com/xml/rss/all.xml');
-      return feed.items.map(i => ({ title: i.title, url: i.link, publishedAt: i.pubDate }));
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  kyivindependent: {
+    label: 'Kyiv Independent',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://kyivindependent.com/feed/');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  kyivpost: {
+    label: 'Kyiv Post',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://www.kyivpost.com/feed');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  unian: {
+    label: 'UNIAN',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://www.unian.net/rss/news');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  pravda: {
+    label: 'Ukrainska Pravda',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://www.pravda.com.ua/rss/view_news/');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  ukrinform: {
+    label: 'Ukrinform',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://www.ukrinform.net/block-lastnews?format=xml');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  rferl: {
+    label: 'RFE/RL',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://www.rferl.org/api/zmgqpqe$mggp');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  liga: {
+    label: 'Liga',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://news.google.com/rss/search?q=liga.net&hl=en-US&gl=US&ceid=US:en');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  rbc: {
+    label: 'RBC Ukraine',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://news.google.com/rss/search?q=rbc.ua&hl=en-US&gl=US&ceid=US:en');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  suspilne: {
+    label: 'Suspilne',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://news.google.com/rss/search?q=suspilne&hl=en-US&gl=US&ceid=US:en');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  hromadske: {
+    label: 'Hromadske',
+    fetch: async (axios, parser) => {
+      const feed = await parser.parseURL('https://news.google.com/rss/search?q=hromadske&hl=en-US&gl=US&ceid=US:en');
+      return feed.items.map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
     }
   }
 };


### PR DESCRIPTION
## Summary
- upgrade server with SSE news streaming
- serve Swagger documentation
- allow new Ukrainian news feeds
- expose news text and image fields
- update React client for SSE and add fade transition

## Testing
- `npm test --prefix server` *(fails: no test specified)*
- `npm test --prefix client` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_684018fbe2788325966248a6a554bf7c