### PR TITLE
Add dynamic Telegram channels and show images

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ inside the `server` directory with these variables:
 TELEGRAM_API_ID=your_api_id
 TELEGRAM_API_HASH=your_api_hash
 TELEGRAM_SESSION=your_session_string
+# Optionally provide a default channel
 TELEGRAM_CHANNEL=@your_channel
 ```
 
@@ -58,3 +59,7 @@ node login-telegram.js
 ```
 and following the interactive prompts. The script will output a session string
 to paste into the `.env` file.
+
+Once the server is running you can add additional Telegram channels from the UI
+by pasting the channel link into the input above the sources table. The channel
+name will be resolved automatically and added as a selectable source.

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -33,6 +33,12 @@
   animation: slide-fade .5s forwards;
 }
 
+.news-item img {
+  max-width: 100%;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
 .news-item pre {
   margin: 0;
   white-space: pre-wrap;
@@ -46,6 +52,12 @@
 
 .controls {
   margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tg-input {
+  margin-bottom: 0.5rem;
   display: flex;
   gap: 0.5rem;
 }

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -1,5 +1,5 @@
 const iconv = require('iconv-lite');
-const fetchTelegram = require('./telegram');
+const { fetchChannelMessages } = require('./telegram');
 
 async function fetchFeed(url, axios, parser) {
   const res = await axios.get(url, { responseType: 'arraybuffer', maxRedirects: 5 });
@@ -206,10 +206,10 @@ module.exports = {
   },
   telegram: {
     label: 'Telegram Channel',
-    fetch: async () => {
-      const channel = process.env.TELEGRAM_CHANNEL;
+    fetch: async (_, __, options) => {
+      const channel = options?.channel || process.env.TELEGRAM_CHANNEL;
       if (!channel) throw new Error('TELEGRAM_CHANNEL is not defined');
-      return fetchTelegram(channel);
+      return fetchChannelMessages(channel);
     }
   }
 };


### PR DESCRIPTION
## Summary
- add server endpoint to resolve Telegram channel info
- allow specifying tg channels dynamically via source IDs
- fetch first image from Telegram posts
- enhance React app with dynamic source input and nicer item view
- update styles for images and input
- document how to add channels dynamically

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684091a719c08325a1fd282705ece412