### PR TITLE
Add feed limits and Telegram feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,16 @@ TELEGRAM_API_HASH=your_api_hash
 TELEGRAM_SESSION=your_session_string
 # Optionally provide a default channel
 TELEGRAM_CHANNEL=@your_channel
+TG_INTEGRATION_FF=true
 ```
+
+For the React client, create a `.env` inside the `client` directory with:
+
+```bash
+VITE_TG_INTEGRATION_FF=true
+```
+
+Set the value to `false` to completely disable Telegram integration in both the server and UI.
 
 Generate `TELEGRAM_SESSION` by running:
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,6 @@
 import { useState, useEffect } from 'react'
+
+const TG_ENABLED = import.meta.env.VITE_TG_INTEGRATION_FF === 'true'
 import './App.css'
 
 const INITIAL_SOURCES = {
@@ -32,6 +34,7 @@ function App() {
   }
 
   const addChannel = async () => {
+    if (!TG_ENABLED) return
     const url = channelUrl.trim()
     if (!url) return
     try {
@@ -91,10 +94,12 @@ function App() {
   return (
     <div className="App">
       <h3>News Aggregator</h3>
-      <div className="tg-input">
-        <input value={channelUrl} onChange={e => setChannelUrl(e.target.value)} placeholder="Telegram channel link" />
-        <button onClick={addChannel}>Add</button>
-      </div>
+      {TG_ENABLED && (
+        <div className="tg-input">
+          <input value={channelUrl} onChange={e => setChannelUrl(e.target.value)} placeholder="Telegram channel link" />
+          <button onClick={addChannel}>Add</button>
+        </div>
+      )}
       <table className="sources">
         <thead>
           <tr>

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -1,5 +1,6 @@
 const iconv = require('iconv-lite');
 const { fetchChannelMessages } = require('./telegram');
+const tgEnabled = process.env.TG_INTEGRATION_FF === 'true';
 
 async function fetchFeed(url, axios, parser) {
   const res = await axios.get(url, { responseType: 'arraybuffer', maxRedirects: 5 });
@@ -8,12 +9,12 @@ async function fetchFeed(url, axios, parser) {
   return parser.parseString(xml);
 }
 
-module.exports = {
+const sources = {
   bbc: {
     label: 'BBC',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('http://feeds.bbci.co.uk/news/world/rss.xml', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -26,7 +27,7 @@ module.exports = {
     label: 'CNN',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('http://rss.cnn.com/rss/cnn_world.rss', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -39,7 +40,7 @@ module.exports = {
     label: 'Reuters',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://news.google.com/rss/search?q=Reuters&hl=en-US&gl=US&ceid=US:en', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -52,7 +53,7 @@ module.exports = {
     label: 'The Guardian',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.theguardian.com/world/rss', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -65,7 +66,7 @@ module.exports = {
     label: 'Al Jazeera',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.aljazeera.com/xml/rss/all.xml', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -78,7 +79,7 @@ module.exports = {
     label: 'Kyiv Independent',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://kyivindependent.com/feed/rss/', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -91,7 +92,7 @@ module.exports = {
     label: 'Kyiv Post',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.kyivpost.com/feed', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -104,7 +105,7 @@ module.exports = {
     label: 'UNIAN',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://rss.unian.net/site/news_eng.rss', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -117,7 +118,7 @@ module.exports = {
     label: 'Ukrainska Pravda',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.pravda.com.ua/rss/view_news/', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -130,7 +131,7 @@ module.exports = {
     label: 'Ukrinform',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.ukrinform.net/rss/block-lastnews', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -143,7 +144,7 @@ module.exports = {
     label: 'RFE/RL',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://www.rferl.org/api/', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -156,7 +157,7 @@ module.exports = {
     label: 'Liga',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://news.google.com/rss/search?q=liga.net&hl=en-US&gl=US&ceid=US:en', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -169,7 +170,7 @@ module.exports = {
     label: 'RBC Ukraine',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://news.google.com/rss/search?q=rbc.ua&hl=en-US&gl=US&ceid=US:en', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -182,7 +183,7 @@ module.exports = {
     label: 'Suspilne',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://news.google.com/rss/search?q=suspilne&hl=en-US&gl=US&ceid=US:en', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -195,7 +196,7 @@ module.exports = {
     label: 'Hromadske',
     fetch: async (axios, parser) => {
       const feed = await fetchFeed('https://news.google.com/rss/search?q=hromadske&hl=en-US&gl=US&ceid=US:en', axios, parser);
-      return feed.items.map(i => ({
+      return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
         publishedAt: i.pubDate,
@@ -204,12 +205,17 @@ module.exports = {
       }));
     }
   },
-  telegram: {
+};
+
+if (tgEnabled) {
+  sources.telegram = {
     label: 'Telegram Channel',
     fetch: async (_, __, options) => {
       const channel = options?.channel || process.env.TELEGRAM_CHANNEL;
       if (!channel) throw new Error('TELEGRAM_CHANNEL is not defined');
       return fetchChannelMessages(channel);
     }
-  }
-};
+  };
+}
+
+module.exports = sources;

--- a/server/sources/telegram.js
+++ b/server/sources/telegram.js
@@ -36,7 +36,7 @@ async function fetchChannelInfo(url) {
 async function fetchChannelMessages(channel) {
   const client = await getClient();
   const peer = await client.getInputEntity(channel);
-  const history = await client.invoke(new Api.messages.GetHistory({ peer, limit: 50 }));
+  const history = await client.invoke(new Api.messages.GetHistory({ peer, limit: 2 }));
   const msgs = history.messages
     .filter(m => m.message)
     .map(async (m) => {


### PR DESCRIPTION
## Summary
- limit RSS and Telegram fetchers to last 2 items
- toggle Telegram integration via `TG_INTEGRATION_FF`
- hide Telegram UI when disabled
- document new environment variables

## Testing
- `npm test --prefix server --silent`
- `npm test --prefix client --silent`


------
https://chatgpt.com/codex/tasks/task_e_684095d63e708325af456caeb1df4785