### PR TITLE
Improve scraping threshold and Telegram style

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -41,6 +41,41 @@
   margin-bottom: 0.5rem;
 }
 
+.tg-post {
+  background-color: #2c3137;
+  border: 1px solid #3a3f43;
+  border-radius: 8px;
+  padding: 0.5rem;
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.tg-post-title {
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+.tg-post img {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.tg-post-text {
+  white-space: pre-wrap;
+}
+
+.tg-post-footer {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: #aaa;
+  margin-top: 0.5rem;
+}
+
 .news-item pre {
   margin: 0;
   white-space: pre-wrap;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -144,12 +144,15 @@ function App() {
               {mode === 'json' ? (
                 <pre>{JSON.stringify(item, null, 2)}</pre>
               ) : (
-                <>
-                  <h4>{item.title}</h4>
+                <div className="tg-post">
+                  <div className="tg-post-title">{item.title}</div>
                   {item.image && <img src={item.image} alt="" />}
-                  <div dangerouslySetInnerHTML={{ __html: item.html || `<p>${item.text}</p>` }} />
-                  <a href={item.url} target="_blank" rel="noreferrer">{item.url}</a>
-                </>
+                  <div className="tg-post-text" dangerouslySetInnerHTML={{ __html: item.html || `<p>${item.text}</p>` }} />
+                  <div className="tg-post-footer">
+                    <span>{new Date(item.publishedAt).toLocaleString()}</span>
+                    <a href={item.url} target="_blank" rel="noreferrer">Open</a>
+                  </div>
+                </div>
               )}
             </div>
           ))}

--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,7 @@ const iconv = require('iconv-lite');
 const TG_ENABLED = process.env.TG_INTEGRATION_FF === 'true';
 const sources = require('./sources');
 const { fetchChannelInfo } = TG_ENABLED ? require('./sources/telegram') : {};
-const MIN_TEXT_LENGTH = 200;
+const MIN_TEXT_LENGTH = 400;
 
 class Queue {
   constructor(concurrency = 2) {


### PR DESCRIPTION
## Summary
- bump text length threshold to 400 characters
- render news in a Telegram-like style when the Render option is chosen

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a5286a448325a3a0be4dede39d63