### PR TITLE
Update news sources and improve article scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ This project provides a simple Node.js server and React client that aggregate wo
 - Ukrainska Pravda
 - Ukrinform
 - RFE/RL
-- Liga
 - RBC Ukraine
 - Suspilne
+- Sky News
+- Fox News
 - Hromadske
 - Telegram Channel
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,8 +15,9 @@ const INITIAL_SOURCES = {
   pravda: 'Ukrainska Pravda',
   ukrinform: 'Ukrinform',
   rferl: 'RFE/RL',
-  liga: 'Liga',
   rbc: 'RBC Ukraine',
+  skynews: 'Sky News',
+  foxnews: 'Fox News',
   suspilne: 'Suspilne',
   hromadske: 'Hromadske'
 }

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -153,10 +153,10 @@ const sources = {
       }));
     }
   },
-  liga: {
-    label: 'Liga',
+  rbc: {
+    label: 'RBC Ukraine',
     fetch: async (axios, parser) => {
-      const feed = await fetchFeed('https://news.google.com/rss/search?q=liga.net&hl=en-US&gl=US&ceid=US:en', axios, parser);
+      const feed = await fetchFeed('https://news.google.com/rss/search?q=rbc.ua&hl=en-US&gl=US&ceid=US:en', axios, parser);
       return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,
@@ -166,10 +166,23 @@ const sources = {
       }));
     }
   },
-  rbc: {
-    label: 'RBC Ukraine',
+  skynews: {
+    label: 'Sky News',
     fetch: async (axios, parser) => {
-      const feed = await fetchFeed('https://news.google.com/rss/search?q=rbc.ua&hl=en-US&gl=US&ceid=US:en', axios, parser);
+      const feed = await fetchFeed('https://feeds.skynews.com/feeds/rss/world.xml', axios, parser);
+      return feed.items.slice(0, 2).map(i => ({
+        title: i.title,
+        url: i.link,
+        publishedAt: i.pubDate,
+        text: i.contentSnippet || i.content || null,
+        image: i.enclosure?.url || null
+      }));
+    }
+  },
+  foxnews: {
+    label: 'Fox News',
+    fetch: async (axios, parser) => {
+      const feed = await fetchFeed('https://feeds.foxnews.com/foxnews/world', axios, parser);
       return feed.items.slice(0, 2).map(i => ({
         title: i.title,
         url: i.link,


### PR DESCRIPTION
## Summary
- delete paywalled Liga feed
- add Sky News and Fox News feeds
- always scrape full article text and images
- document new sources in README

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a76b415c8325b43df1c4226887b6