### PR TITLE
Fix invalid Telegram command in bot

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -15,7 +15,7 @@ const bot = new TelegramBot(token, { polling: true });
 
 bot.setMyCommands([
   { command: 'connect', description: 'Connect to news server' },
-  { command: 'show-news', description: 'Show new news' },
+  { command: 'show_news', description: 'Show new news' },
   { command: 'stop', description: 'Stop sending news' },
   { command: 'disconnect', description: 'Disconnect from news server' }
 ]);
@@ -88,7 +88,7 @@ function askPermission(chatId) {
   });
 }
 
-bot.onText(/\/show-news/, async (msg) => {
+bot.onText(/\/show_news/, async (msg) => {
   const chatId = msg.chat.id;
   try {
     await ensureConnection(chatId);


### PR DESCRIPTION
## Summary
- fix Telegram command name with underscores

## Testing
- `npm test --prefix client` *(fails: vitest not found)*
- `npx --yes vitest run --dir client` *(fails: ReferenceError: describe is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684443b6a6dc8325827bc597eea69dbd