### PR TITLE
Implement bot status updates and full source connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Bot commands:
 - `/stop` – stop sending news
 - `/disconnect` – close the connection
 
+The bot automatically subscribes to all available sources and will send a short
+status message every 30 seconds if no new headlines arrive.
+
 ### Telegram Setup
 
 To enable Telegram channel fetching without using a bot, create a `.env` file


### PR DESCRIPTION
## Summary
- connect Telegram bot to all available news sources
- send status messages when no news arrives
- document new bot behaviour

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844460840f88325a7b0fb80a3281cb2