### PR TITLE
Add history flag for news endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run install-all
 ```bash
 npm start
 ```
-The server listens on **http://localhost:3001** and exposes an SSE endpoint `/api/news?sources=source1,source2` streaming JSON objects. Swagger documentation is available at `/docs`.
+The server listens on **http://localhost:3001** and exposes an SSE endpoint `/api/news?sources=source1,source2&history=true` streaming JSON objects. Set `history=false` to skip the initial batch of two recent items from each source. Swagger documentation is available at `/docs`.
 
 The React UI will open on **http://localhost:3000**.
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -63,7 +63,7 @@ function ensureConnection(chatId) {
     if (connections.has(chatId)) {
       return resolve();
     }
-    const es = new EventSource(`${serverUrl}/api/news?sources=${ALL_SOURCES.join(',')}`);
+    const es = new EventSource(`${serverUrl}/api/news?sources=${ALL_SOURCES.join(',')}&history=false`);
     const state = { es, show: false, seen: new Set(), lastNews: Date.now(), lastPing: Date.now(), interval: null };
     connections.set(chatId, state);
     es.onopen = () => {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -62,6 +62,7 @@ function App() {
     if (es) es.close()
     const params = new URLSearchParams()
     params.append('sources', selected.join(','))
+    params.append('history', 'true')
     const eventSource = new EventSource(`http://localhost:3001/api/news?${params}`)
     setEs(eventSource)
     eventSource.onmessage = (e) => {


### PR DESCRIPTION
## Summary
- add `history` query flag for `/api/news` to optionally skip initial items
- update bot to disable history
- send history from React client
- document the new flag

## Testing
- `npm run lint --prefix client` *(fails: 99 errors)*
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6844489662fc83258ae796eaae3e5a33