### PR TITLE
Fix bot news posting

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -137,9 +137,15 @@ function ensureConnection(chatId) {
         if (data.url && state.seen.has(data.url)) return;
         if (data.url) state.seen.add(data.url);
         state.lastNews = Date.now();
-        const target = state.channelId || chatId;
-        bot.sendMessage(String(target), `\u0060\u0060\u0060\n${JSON.stringify(data, null, 2)}\n\u0060\u0060\u0060`, { parse_mode: 'Markdown' })
-          .catch(e => console.error('Failed to send message to', target, e.message));
+        const targets = [chatId];
+        if (state.channelId && state.channelId !== String(chatId)) {
+          targets.push(state.channelId);
+        }
+        const text = `*${data.title}*\n${data.url}`;
+        for (const t of targets) {
+          bot.sendMessage(String(t), text, { parse_mode: 'Markdown' })
+            .catch(e => console.error('Failed to send message to', t, e.message));
+        }
       } catch {
         // ignore
       }


### PR DESCRIPTION
## Summary
- send news messages to both chat and channel
- avoid Telegram's message length limit by only sending title and URL

## Testing
- `npm test --prefix client` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684592158fa083258baee175c3a2fac8