### PR TITLE
Fix bot token loading

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,6 +1,10 @@
 const fs = require('fs');
 const path = require('path');
-require('dotenv').config();
+const dotenv = require('dotenv');
+// Load env from project root and server directory so the bot works
+// regardless of the current working directory
+dotenv.config({ path: path.resolve(__dirname, '../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../server/.env') });
 const TelegramBot = require('node-telegram-bot-api');
 
 const token = process.env.BOT_TOKEN;


### PR DESCRIPTION
## Summary
- load `.env` from repo root and server folder so telegram bot works when server is started from any directory

## Testing
- `node -e "const b=require('./bot'); console.log(Object.keys(b));"`

------
https://chatgpt.com/codex/tasks/task_e_685413dd7494832590e4f668df05b3b5