### PR TITLE
Add logging for telegram scraping

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -142,13 +142,15 @@ async function scrapeTelegramChannel(url) {
         }
       }
       const time = $(el).find('time').attr('datetime') || null;
-      posts.push({
+      const post = {
         url: link,
         title: text.slice(0, 50) + (text.length > 50 ? '...' : ''),
         text,
         image,
         publishedAt: time
-      });
+      };
+      log(`Scraped TG post: ${post.title} - ${post.url}`);
+      posts.push(post);
     });
     return posts.slice(-2);
   } catch (err) {
@@ -329,6 +331,7 @@ app.get('/api/tgnews', async (req, res) => {
           seen.add(item.url);
           if (!includeHistory && initial) continue;
           res.write(`data: ${JSON.stringify({ ...item, source: url })}\n\n`);
+          log(`Sent post ${item.url}`);
         }
       } catch (err) {
         console.error('Error fetching tg source', url, err.message);


### PR DESCRIPTION
## Summary
- log each scraped Telegram post
- log when a post is sent to the client

## Testing
- `npm --prefix client test`
- `npm --prefix server test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854337f0f3c8325a0bc44d2f42b582b