### PR TITLE
Fix Telegram markup scraping

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,7 @@
         "http-proxy-agent": "^6.0.0",
         "https-proxy-agent": "^7.0.2",
         "iconv-lite": "^0.6.3",
+        "marked": "^15.0.12",
         "node-telegram-bot-api": "^0.61.0",
         "rss-parser": "^3.13.0",
         "swagger-jsdoc": "^6.2.8",
@@ -2230,6 +2231,18 @@
       "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
       "integrity": "sha512-j7MJE+TuT51q9ggt4fSgVqro163BEFjAt3u97IqU+JA2DkWl80nFTrowzLpZ/BnpN7rrl0JA/593NAdd8p/scQ==",
       "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "swagger-ui-express": "^5.0.1",
     "node-telegram-bot-api": "^0.61.0",
     "unfluff": "^3.2.0",
-    "cheerio": "^1.0.0-rc.12"
+    "cheerio": "^1.0.0-rc.12",
+    "marked": "^15.0.12"
   }
 }


### PR DESCRIPTION
## Summary
- parse full Telegram post markdown
- convert Telegram markdown to HTML
- strip blob images from Telegram posts
- include `marked` library for Markdown parsing

## Testing
- `npm test --prefix server` *(fails: no test specified)*
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68543773c8288325b9fe48eff79292d5