### PR TITLE
Fix Telegram media scraping

### DIFF
--- a/client/src/components/NewsItem.jsx
+++ b/client/src/components/NewsItem.jsx
@@ -8,7 +8,9 @@ export default function NewsItem({ item, mode }) {
       ) : (
         <div className="tg-post">
           <div className="tg-post-title">{item.title}</div>
-          {item.image && <img src={item.image} alt="" />}
+          {(item.media?.[0] || item.image) && (
+            <img src={item.media?.[0] || item.image} alt="" />
+          )}
           <div className="tg-post-text" dangerouslySetInnerHTML={{ __html: item.html || `<p>${item.text}</p>` }} />
           <div className="tg-post-footer">
             <span>{new Date(item.publishedAt).toLocaleString()}</span>

--- a/client/src/components/__tests__/NewsItem.test.jsx
+++ b/client/src/components/__tests__/NewsItem.test.jsx
@@ -8,6 +8,7 @@ describe('NewsItem', () => {
     text: 'text',
     html: '<p>text</p>',
     image: 'img.jpg',
+    media: ['img.jpg'],
     publishedAt: new Date('2024-01-01').toISOString()
   }
 


### PR DESCRIPTION
## Summary
- capture images and videos from Telegram posts by parsing the standard channel page
- expose all media URLs in new `media` array while keeping the first as `image`
- update UI to display first media item
- adjust tests for new property

## Testing
- `npm test --prefix client -- --run`

------
https://chatgpt.com/codex/tasks/task_e_685442a7da588325984bc672b0737075