### PR TITLE
Improve Telegram post rendering

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -51,6 +51,24 @@
   margin: 0 auto;
 }
 
+.tg-post-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.tg-post-header img {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.tg-post-channel {
+  font-weight: bold;
+}
+
 .tg-post-title {
   font-weight: bold;
   margin-bottom: 0.5rem;

--- a/client/src/components/NewsItem.jsx
+++ b/client/src/components/NewsItem.jsx
@@ -7,6 +7,10 @@ export default function NewsItem({ item, mode }) {
         <pre>{JSON.stringify(item, null, 2)}</pre>
       ) : (
         <div className="tg-post">
+          <div className="tg-post-header">
+            {item.channelImage && <img src={item.channelImage} alt="" />}
+            <span className="tg-post-channel">{item.channelTitle}</span>
+          </div>
           <div className="tg-post-title">{item.title}</div>
           {(item.media?.[0] || item.image) && (
             <img src={item.media?.[0] || item.image} alt="" />

--- a/client/src/components/__tests__/NewsItem.test.jsx
+++ b/client/src/components/__tests__/NewsItem.test.jsx
@@ -9,7 +9,9 @@ describe('NewsItem', () => {
     html: '<p>text</p>',
     image: 'img.jpg',
     media: ['img.jpg'],
-    publishedAt: new Date('2024-01-01').toISOString()
+    publishedAt: new Date('2024-01-01').toISOString(),
+    channelTitle: 'Channel',
+    channelImage: 'ch.jpg'
   }
 
   test('renders json', () => {
@@ -24,8 +26,14 @@ describe('NewsItem', () => {
 
   test('renders image when present', () => {
     render(<NewsItem item={item} mode="render" />)
-    const img = document.querySelector('img')
-    expect(img).toHaveAttribute('src', 'img.jpg')
+    const imgs = document.querySelectorAll('img')
+    expect(imgs[0]).toHaveAttribute('src', 'ch.jpg')
+    expect(imgs[1]).toHaveAttribute('src', 'img.jpg')
+  })
+
+  test('shows channel title', () => {
+    render(<NewsItem item={item} mode="render" />)
+    expect(screen.getByText('Channel')).toBeInTheDocument()
   })
 
   test('renders link', () => {

--- a/server/index.js
+++ b/server/index.js
@@ -129,6 +129,8 @@ async function scrapeTelegramChannel(url) {
   try {
     const res = await axiosInstance.get(pageUrl, { responseType: 'text', maxRedirects: 5 });
     const $ = cheerio.load(res.data);
+    const channelTitle = $('meta[property="og:title"]').attr('content') || channel;
+    const channelImage = $('meta[property="og:image"]').attr('content') || null;
     const messages = $('.js-widget_message').filter((_, el) => !$(el).hasClass('service_message')).slice(-2);
     const posts = [];
     messages.each((_, el) => {
@@ -141,6 +143,7 @@ async function scrapeTelegramChannel(url) {
       const media = [];
       $(el).find('a.tgme_widget_message_photo_wrap, video, img').each((_, m) => {
         const mm = $(m);
+        if (mm.closest('.tgme_widget_message_user').length) return;
         if (mm.is('a')) {
           const style = mm.attr('style') || '';
           const m2 = /url\('([^']+)'\)/.exec(style);
@@ -158,7 +161,9 @@ async function scrapeTelegramChannel(url) {
         html,
         media,
         image: media[0] || null,
-        publishedAt: time
+        publishedAt: time,
+        channelTitle,
+        channelImage
       };
       log(`Scraped TG post: ${post.title} - ${post.url}`);
       posts.push(post);


### PR DESCRIPTION
## Summary
- show channel avatar and name in Telegram posts
- ignore avatar when scraping post media
- add styles for channel info
- update tests

## Testing
- `npm run install-all`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68544619001c8325bf7290354dc19236