### PR TITLE
Fix TG scraping for videos, shrink avatars

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -59,8 +59,8 @@
 }
 
 .tg-post-header img {
-  width: 40px;
-  height: 40px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   object-fit: cover;
 }

--- a/server/index.js
+++ b/server/index.js
@@ -141,18 +141,23 @@ async function scrapeTelegramChannel(url) {
       const html = textEl.html() || '';
       const text = textEl.text().replace(/\s+/g, ' ').trim();
       const media = [];
-      $(el).find('a.tgme_widget_message_photo_wrap, video, img').each((_, m) => {
-        const mm = $(m);
-        if (mm.closest('.tgme_widget_message_user').length) return;
-        if (mm.is('a')) {
-          const style = mm.attr('style') || '';
-          const m2 = /url\('([^']+)'\)/.exec(style);
-          if (m2) media.push(m2[1]);
-        } else {
-          const src = mm.attr('src');
-          if (src && !src.startsWith('data:')) media.push(src);
-        }
-      });
+      $(el)
+        .find(
+          'a.tgme_widget_message_photo_wrap, a.tgme_widget_message_video_player, video, source, img'
+        )
+        .each((_, m) => {
+          const mm = $(m);
+          if (mm.closest('.tgme_widget_message_user').length) return;
+          let url;
+          if (mm.is('a')) {
+            const style = mm.attr('style') || '';
+            const m2 = /url\('([^']+)'\)/.exec(style);
+            if (m2) url = m2[1];
+          } else {
+            url = mm.attr('src') || mm.attr('data-src');
+          }
+          if (url && !url.startsWith('data:') && !media.includes(url)) media.push(url);
+        });
       const time = $(el).find('.tgme_widget_message_date time').attr('datetime') || null;
       const post = {
         url: link,


### PR DESCRIPTION
## Summary
- make Telegram channel avatars smaller
- capture videos and other media when scraping telegram

## Testing
- `npm test --prefix client`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6854485812f88325aa12937613563552