### PR TITLE
Fix Swagger docs for channels

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -250,19 +250,12 @@ async function scrapeTelegramChannel(url) {
 
 /**
  * @openapi
- * /api/telegram-info:
+ * /api/channels:
  *   get:
- *     summary: Get Telegram channel information
- *     parameters:
- *       - in: query
- *         name: url
- *         schema:
- *           type: string
- *         required: true
- *         description: Telegram channel link or username
+ *     summary: List Telegram channels the bot has access to
  *     responses:
  *       200:
- *         description: Channel info
+ *         description: Object containing channel information
  */
 app.get('/api/channels', (req, res) => {
   res.json(listChannels());


### PR DESCRIPTION
## Summary
- update OpenAPI doc block to correctly describe `/api/channels`

## Testing
- `npx vitest run --dir client` *(fails: `ReferenceError: describe is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_6854b0074ac88325af37fae7e5096683