### PR TITLE
Introduce DOMPurify for NewsItem

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "dompurify": "^3.2.6",
         "jsdom": "^26.1.0",
         "prop-types": "^15.8.1",
         "react": "^19.1.0",
@@ -1653,6 +1654,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.5.1.tgz",
@@ -2270,6 +2278,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.163",

--- a/client/package.json
+++ b/client/package.json
@@ -11,10 +11,11 @@
     "test": "vitest"
   },
   "dependencies": {
+    "dompurify": "^3.2.6",
     "jsdom": "^26.1.0",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0",
-    "prop-types": "^15.8.1"
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/components/NewsItem.jsx
+++ b/client/src/components/NewsItem.jsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types'
+import DOMPurify from 'dompurify'
 
 export default function NewsItem({ item, mode }) {
   return (
@@ -15,7 +16,10 @@ export default function NewsItem({ item, mode }) {
           {(item.media?.[0] || item.image) && (
             <img src={item.media?.[0] || item.image} alt="" />
           )}
-          <div className="tg-post-text" dangerouslySetInnerHTML={{ __html: item.html || `<p>${item.text}</p>` }} />
+          <div
+            className="tg-post-text"
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(item.html || `<p>${item.text}</p>`) }}
+          />
           <div className="tg-post-footer">
             <span>{new Date(item.publishedAt).toLocaleString()}</span>
             <a href={item.url} target="_blank" rel="noreferrer">Open</a>

--- a/client/src/components/__tests__/NewsItem.test.jsx
+++ b/client/src/components/__tests__/NewsItem.test.jsx
@@ -45,4 +45,11 @@ describe('NewsItem', () => {
     render(<NewsItem item={item} mode="render" />)
     expect(screen.getByText('1/1/2024', { exact: false })).toBeInTheDocument()
   })
+
+  test('sanitizes html', () => {
+    const unsafe = { ...item, html: '<p>ok</p><script>bad()</script>' }
+    const { container } = render(<NewsItem item={unsafe} mode="render" />)
+    expect(container.querySelectorAll('script').length).toBe(0)
+    expect(screen.getByText('ok')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary
- add DOMPurify dependency
- sanitize `item.html` in `NewsItem` before injecting HTML
- verify sanitization behavior in tests

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6854b03746d48325838216c753a6c3f3