### PR TITLE
Add media post support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,19 @@ Put the Telegram channel links you want to post to in `server/admin-channels.jso
 ```
 
 On startup the bot resolves these links to channel IDs and rewrites the file with the channel information. It also keeps track of channels where it gains administrator rights. The React client loads this list so you can choose where to post news.
+
+### POST `/api/post`
+
+Send messages or media to a Telegram channel. The endpoint accepts a JSON body:
+
+```json
+{
+  "channel": "<channel id>",
+  "text": "optional caption or message",
+  "media": "optional https url to an image or video"
+}
+```
+
+When `media` is provided, the server sends a photo or video to the channel. If
+the URL ends with `.mp4` a video is sent, otherwise a photo. When only `text` is
+present it falls back to a regular message.

--- a/bot/index.js
+++ b/bot/index.js
@@ -113,7 +113,31 @@ async function sendMessage(channel, text) {
   }
 }
 
-module.exports = { listChannels, sendMessage, botEvents };
+async function sendPhoto(channel, url, caption) {
+  try {
+    await bot.sendPhoto(channel, url, { caption, parse_mode: 'Markdown' });
+    console.log('Sent photo to', channel);
+    botEvents.emit('log', `Sent photo to ${channel}`);
+  } catch (e) {
+    console.error('Failed to send photo', channel, e.message);
+    botEvents.emit('log', `Failed to send photo to ${channel}: ${e.message}`);
+    throw e;
+  }
+}
+
+async function sendVideo(channel, url, caption) {
+  try {
+    await bot.sendVideo(channel, url, { caption, parse_mode: 'Markdown' });
+    console.log('Sent video to', channel);
+    botEvents.emit('log', `Sent video to ${channel}`);
+  } catch (e) {
+    console.error('Failed to send video', channel, e.message);
+    botEvents.emit('log', `Failed to send video to ${channel}: ${e.message}`);
+    throw e;
+  }
+}
+
+module.exports = { listChannels, sendMessage, sendPhoto, sendVideo, botEvents };
 
 (async () => {
   await loadChannels();

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -91,11 +91,12 @@ function App() {
         const msg = tabRef.current === 'tg'
           ? `${item.text || item.title}\n${item.url}`
           : `*${item.title}*\n${item.url}`
+        const media = item.media?.find(m => m.endsWith('.mp4')) || item.media?.[0]
         channelsRef.current.forEach(ch => {
           fetch('http://localhost:3001/api/post', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ channel: ch, text: msg })
+            body: JSON.stringify({ channel: ch, text: msg, media })
           }).catch(() => {})
         })
       }

--- a/server/index.js
+++ b/server/index.js
@@ -14,7 +14,7 @@ const { telegram_scraper } = require('telegram-scraper');
 const sources = require('./sources');
 const fs = require('fs');
 const path = require('path');
-const { listChannels, sendMessage, botEvents } = require('../bot');
+const { listChannels, sendMessage, sendPhoto, sendVideo, botEvents } = require('../bot');
 
 function log(message) {
   console.log(message);
@@ -270,10 +270,19 @@ app.get('/api/channels', (req, res) => {
 
 app.post('/api/post', async (req, res) => {
   try {
-    const { channel, text } = req.body;
-    if (!channel || !text) return res.status(400).json({ error: 'channel and text required' });
+    const { channel, text, media } = req.body;
+    if (!channel) return res.status(400).json({ error: 'channel required' });
+    if (!text && !media) return res.status(400).json({ error: 'text or media required' });
     log(`Posting to ${channel}`);
-    await sendMessage(channel, text);
+    if (media) {
+      if (media.toLowerCase().endsWith('.mp4')) {
+        await sendVideo(channel, media, text);
+      } else {
+        await sendPhoto(channel, media, text);
+      }
+    } else {
+      await sendMessage(channel, text);
+    }
     log(`Posted to ${channel}`);
     res.json({ ok: true });
   } catch (e) {


### PR DESCRIPTION
## Summary
- add sendPhoto and sendVideo helpers
- extend /api/post to support sending media
- forward `item.media` from the client when posting news
- document the media field in README

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6854afef962c8325baa62ddf83dc77a2