### PR TITLE
Improve filter creation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -268,8 +268,17 @@ function App() {
       ) : (
         <FiltersTab filters={filters} setFilters={setFilters} />
       )}
-      <ModeToggle mode={mode} setMode={setMode} />
-      <Controls startGet={tab === 'news' ? startGetting : startScraping} startPost={startPosting} stop={stop} startLabel={tab === 'news' ? 'Start Getting' : tab === 'tg' ? 'Start Scraping' : 'Start Getting'} />
+      {tab !== 'filters' && (
+        <>
+          <ModeToggle mode={mode} setMode={setMode} />
+          <Controls
+            startGet={tab === 'news' ? startGetting : startScraping}
+            startPost={startPosting}
+            stop={stop}
+            startLabel={tab === 'news' ? 'Start Getting' : tab === 'tg' ? 'Start Scraping' : 'Start Getting'}
+          />
+        </>
+      )}
       <NewsList news={news} mode={mode} />
     </div>
   )

--- a/client/src/components/FiltersTab.jsx
+++ b/client/src/components/FiltersTab.jsx
@@ -1,12 +1,25 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 export default function FiltersTab({ filters, setFilters }) {
   const [showForm, setShowForm] = useState(false)
   const [title, setTitle] = useState('')
   const [model, setModel] = useState('gpt-3.5-turbo')
+  const [models, setModels] = useState([])
   const [instructions, setInstructions] = useState('')
   const [files, setFiles] = useState([])
+
+  useEffect(() => {
+    fetch('http://localhost:3001/api/models')
+      .then(r => r.json())
+      .then(data => {
+        if (Array.isArray(data) && data.length) {
+          setModels(data)
+          setModel(data[0])
+        }
+      })
+      .catch(() => {})
+  }, [])
 
   const create = () => {
     const fd = new FormData()
@@ -40,8 +53,16 @@ export default function FiltersTab({ filters, setFilters }) {
         <div className="filter-form">
           <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" />
           <select value={model} onChange={e => setModel(e.target.value)}>
-            <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
-            <option value="gpt-4-turbo">gpt-4-turbo</option>
+            {models.length === 0 ? (
+              <>
+                <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+                <option value="gpt-4-turbo">gpt-4-turbo</option>
+              </>
+            ) : (
+              models.map(m => (
+                <option key={m} value={m}>{m}</option>
+              ))
+            )}
           </select>
           <textarea value={instructions} onChange={e => setInstructions(e.target.value)} placeholder="Instructions" />
           <input type="file" multiple onChange={e => setFiles(Array.from(e.target.files))} />

--- a/server/index.js
+++ b/server/index.js
@@ -351,6 +351,24 @@ app.delete('/api/tg-sources', (req, res) => {
   res.json({ ok: true });
 });
 
+app.get('/api/models', async (req, res) => {
+  try {
+    const key = process.env.OPENAI_API_KEY;
+    if (!key) return res.status(500).json({ error: 'OPENAI_API_KEY not set' });
+    const resp = await axiosInstance.get('https://api.openai.com/v1/models', {
+      headers: { Authorization: `Bearer ${key}` }
+    });
+    const models = resp.data.data
+      .map(m => m.id)
+      .filter(id => id.startsWith('gpt-'))
+      .sort();
+    res.json(models);
+  } catch (e) {
+    console.error('Failed to list models', e.message);
+    res.status(500).json({ error: e.message });
+  }
+});
+
 app.get('/api/filters', (req, res) => {
   res.json(filters);
 });


### PR DESCRIPTION
## Summary
- query OpenAI for available GPT models
- fetch models on the Filters tab
- hide mode toggle and post controls while editing filters

## Testing
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_685aa5658c4c832585ee099469e92557