### PR TITLE
Fix OpenAI assistant creation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -394,7 +394,9 @@ app.post('/api/filters', upload.array('attachments'), async (req, res) => {
       model,
       instructions,
       tools: fileIds.length ? [{ type: 'file_search' }] : [],
-      file_ids: fileIds
+      tool_resources: fileIds.length
+        ? { file_search: { vector_stores: [{ file_ids: fileIds }] } }
+        : undefined
     });
     const info = { id: createResp.id, title, model, instructions, file_ids: fileIds };
     filters.push(info);


### PR DESCRIPTION
## Summary
- update filter creation call to use `tool_resources`

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `node -e "require('./server')"` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685ab3fc0bec8325bffe10a360352197