### PR TITLE
Add endpoint for updating filter files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,10 @@ curl -F title=News -F model=gpt-4o \
 
 Attachments are uploaded as part of the multipart request using the `attachments` field. When creation succeeds the API returns the filter id which can later be used to evaluate posts via `/api/filters/<id>/evaluate`.
 
+Additional knowledge can be added later using `/api/filters/<id>/files`:
+
+```bash
+curl -F attachments=@notes.txt \
+     http://localhost:3001/api/filters/<id>/files
+```
+


### PR DESCRIPTION
## Summary
- store vector store id when creating filters
- add `/api/filters/:id/files` endpoint to attach more files
- document how to add extra knowledge

## Testing
- `npm test --prefix client`
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685abb0f389c8325852758173dcc8bac