### PR TITLE
Handle vector store creation on file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ curl -F title=News -F model=gpt-4o \
      http://localhost:3001/api/filters
 ```
 
-Attachments are uploaded as part of the multipart request using the `attachments` field. When creation succeeds the API returns the filter id which can later be used to evaluate posts via `/api/filters/<id>/evaluate`.
+Upload files first using the `/api/vector-stores` endpoint which creates a vector store. Pass the returned `vector_store_id` when creating the filter. When creation succeeds the API returns the filter id which can later be used to evaluate posts via `/api/filters/<id>/evaluate`.
 
 Additional knowledge can be added later using `/api/filters/<id>/files`:
 


### PR DESCRIPTION
## Summary
- create `/api/vector-stores` endpoint for uploading files and creating an OpenAI vector store
- connect new vector store to assistants when saving filters
- call the new endpoint from the Filters tab
- document new workflow for filters

## Testing
- `npm install --prefix client`
- `npm install --prefix server`
- `npx --yes vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685aca5f01e08325ae4b5d60586a4a7b