### PR TITLE
Improve logging behavior

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -221,6 +221,7 @@ function App() {
     const esLogs = new EventSource('http://localhost:3001/api/logs')
     esLogs.onmessage = (e) => {
       const data = JSON.parse(e.data)
+      console.log(data.message)
       setLogs(prev => [data.message, ...prev].slice(0, 50))
     }
     return () => esLogs.close()

--- a/server/index.js
+++ b/server/index.js
@@ -590,10 +590,10 @@ app.get('/api/tgnews', async (req, res) => {
         log(`Scraping TG ${url}`);
         const items = await scrapeTelegramChannel(url);
         for (const item of items) {
-          log(`Found post ${item.url}`);
           if (seen.has(item.url)) continue;
           seen.add(item.url);
           if (!includeHistory && initial) continue;
+          log(`Found post ${item.url}`);
           res.write(`data: ${JSON.stringify({ ...item, source: url })}\n\n`);
           log(`Sent post ${item.url}`);
         }


### PR DESCRIPTION
## Summary
- avoid duplicate log entries for TG posts
- mirror log messages to browser console

## Testing
- `npm test --silent --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_685bed163670832585ed2e0729ac8e3f