### PR TITLE
Fix approver handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Put the Telegram channel links you want to post to in `server/admin-channels.jso
 On startup the bot resolves these links to channel IDs and rewrites the file with the channel information. It also keeps track of channels where it gains administrator rights. The React client loads this list so you can choose where to post news.
 
 To receive post approval requests, approvers must first start a private chat with
-the bot and run the `/start_approving` command. The bot checks if their numeric
-ID is present in `server/approvers.json` and, when matched, approval messages
-are sent to that chat.
+the bot and run the `/start_approving` command. The bot checks if their
+**username** is listed in `server/approvers.json` and, when matched, approval
+messages are sent to that chat.
 
 ### POST `/api/post`
 

--- a/bot/index.js
+++ b/bot/index.js
@@ -170,4 +170,7 @@ module.exports = { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, r
 
 (async () => {
   await loadChannels();
+  await bot.setMyCommands([
+    { command: 'start_approving', description: 'Receive approval requests' }
+  ]);
 })();

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 
 export default function AdminTab() {
-  const [link, setLink] = useState('')
+  const [username, setUsername] = useState('')
   const [users, setUsers] = useState([])
   const [queue, setQueue] = useState([])
 
@@ -23,19 +23,19 @@ export default function AdminTab() {
   }, [])
 
   const add = () => {
-    if (!link.trim()) return
+    if (!username.trim()) return
     fetch('http://localhost:3001/api/approvers', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ link: link.trim() })
+      body: JSON.stringify({ username: username.trim() })
     }).then(() => {
-      setLink('')
+      setUsername('')
       load()
     }).catch(() => {})
   }
 
-  const remove = (id) => {
-    fetch(`http://localhost:3001/api/approvers?id=${id}`, {
+  const remove = (name) => {
+    fetch(`http://localhost:3001/api/approvers?username=${name}`, {
       method: 'DELETE'
     }).then(load).catch(() => {})
   }
@@ -53,12 +53,12 @@ export default function AdminTab() {
   return (
     <div className="admin-tab">
       <div className="tg-input">
-        <input value={link} onChange={e => setLink(e.target.value)} placeholder="https://t.me/username" />
+        <input value={username} onChange={e => setUsername(e.target.value)} placeholder="@username" />
         <button onClick={add}>Add Approver</button>
       </div>
       <ul>
         {users.map(u => (
-          <li key={u.id}>{u.username || u.title || u.id} <button onClick={() => remove(u.id)}>x</button></li>
+          <li key={u}><span>{u}</span> <button onClick={() => remove(u)}>x</button></li>
         ))}
       </ul>
       <h4>Awaiting Approval</h4>


### PR DESCRIPTION
## Summary
- track approvers by username
- update API and admin UI to use usernames
- set `/start_approving` as the only bot command

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_685fd157af008325b641e7a6ad8129a1