### PR TITLE
Improve telegram approvals and UI

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -166,7 +166,11 @@ function answerCallback(id, text) {
   return bot.answerCallbackQuery(id, { text });
 }
 
-module.exports = { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, resolveLink, sendApprovalRequest, answerCallback };
+function deleteMessage(chatId, messageId) {
+  return bot.deleteMessage(chatId, messageId);
+}
+
+module.exports = { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, resolveLink, sendApprovalRequest, answerCallback, deleteMessage };
 
 (async () => {
   await loadChannels();

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -112,6 +112,42 @@
   gap: 0.5rem;
 }
 
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tabs button {
+  background-color: #1f1f1f;
+  border: 1px solid #555;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+}
+
+.tabs button.active {
+  background-color: #333;
+  border-color: #888;
+}
+
+.channel-select,
+.filter-select,
+.tg-sources {
+  margin-bottom: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tg-sources ul {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+}
+
+.tg-sources li {
+  margin-bottom: 0.25rem;
+}
+
 .tg-input {
   margin-bottom: 0.5rem;
   display: flex;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import TGSources from './components/TGSources.jsx'
 import FilterSelect from './components/FilterSelect.jsx'
 import FiltersTab from './components/FiltersTab.jsx'
 import AdminTab from './components/AdminTab.jsx'
+import Button from './components/ui/Button.jsx'
 
 import './App.css'
 
@@ -51,6 +52,7 @@ function App() {
   const tabRef = useRef(tab)
   const filterRef = useRef(selectedFilter)
   const [, forceTick] = useState(0)
+  const controlsDisabled = tab === 'tg' && (!selectedChannels.length || selectedFilter === 'none')
   const toggle = (source) => {
     setSelected(prev => prev.includes(source) ? prev.filter(s => s !== source) : [...prev, source])
   }
@@ -152,6 +154,10 @@ function App() {
   }
 
   const startScraping = () => {
+    if (!selectedChannels.length || selectedFilter === 'none') {
+      window.alert('Please select at least one channel and a filter before starting.');
+      return;
+    }
     setPosting(false)
     const params = new URLSearchParams()
     params.append('urls', tgUrls.join(','))
@@ -162,6 +168,10 @@ function App() {
   const startPosting = () => {
     if (posting) {
       window.alert('Posting is already started')
+      return
+    }
+    if (tab === 'tg' && (!selectedChannels.length || selectedFilter === 'none')) {
+      window.alert('Please select at least one channel and a filter before starting.');
       return
     }
     if (!window.confirm('Start posting to the selected Telegram channels?')) return
@@ -254,10 +264,10 @@ function App() {
     <div className="App">
       <h3>News Aggregator</h3>
       <div className="tabs">
-        <button onClick={() => setTab('news')} className={tab === 'news' ? 'active' : ''}>News Sources</button>
-        <button onClick={() => setTab('tg')} className={tab === 'tg' ? 'active' : ''}>TG Scraping</button>
-        <button onClick={() => setTab('filters')} className={tab === 'filters' ? 'active' : ''}>Filters</button>
-        <button onClick={() => setTab('admin')} className={tab === 'admin' ? 'active' : ''}>Administration</button>
+        <Button onClick={() => setTab('news')} className={tab === 'news' ? 'active' : ''}>News Sources</Button>
+        <Button onClick={() => setTab('tg')} className={tab === 'tg' ? 'active' : ''}>TG Scraping</Button>
+        <Button onClick={() => setTab('filters')} className={tab === 'filters' ? 'active' : ''}>Filters</Button>
+        <Button onClick={() => setTab('admin')} className={tab === 'admin' ? 'active' : ''}>Administration</Button>
       </div>
       <Logs logs={logs} />
       <ChannelSelect channels={channels} selected={selectedChannels} setSelected={setSelectedChannels} />
@@ -281,6 +291,7 @@ function App() {
             startPost={startPosting}
             stop={stop}
             startLabel={tab === 'news' ? 'Start Getting' : tab === 'tg' ? 'Start Scraping' : 'Start Getting'}
+            disabled={controlsDisabled}
           />
         </>
       )}

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import Button from './ui/Button.jsx'
 
 export default function AdminTab() {
   const [username, setUsername] = useState('')
@@ -54,11 +55,11 @@ export default function AdminTab() {
     <div className="admin-tab">
       <div className="tg-input">
         <input value={username} onChange={e => setUsername(e.target.value)} placeholder="@username" />
-        <button onClick={add}>Add Approver</button>
+        <Button onClick={add}>Add Approver</Button>
       </div>
       <ul>
         {users.map(u => (
-          <li key={u}><span>{u}</span> <button onClick={() => remove(u)}>x</button></li>
+          <li key={u}><span>{u}</span> <Button onClick={() => remove(u)}>x</Button></li>
         ))}
       </ul>
       <h4>Awaiting Approval</h4>
@@ -68,8 +69,8 @@ export default function AdminTab() {
             <div>{p.channel}</div>
             <div>{p.text?.slice(0, 100)}</div>
             {p.media && <img src={p.media} alt="" />}
-            <button onClick={() => approve(p.id)}>Approve</button>
-            <button onClick={() => cancel(p.id)}>Cancel</button>
+            <Button onClick={() => approve(p.id)}>Approve</Button>
+            <Button onClick={() => cancel(p.id)}>Cancel</Button>
           </li>
         ))}
       </ul>

--- a/client/src/components/Controls.jsx
+++ b/client/src/components/Controls.jsx
@@ -1,11 +1,12 @@
 import PropTypes from 'prop-types'
+import Button from './ui/Button.jsx'
 
-export default function Controls({ startGet, startPost, stop, startLabel = 'Start Getting' }) {
+export default function Controls({ startGet, startPost, stop, startLabel = 'Start Getting', disabled = false }) {
   return (
     <div className="controls">
-      <button onClick={startGet}>{startLabel}</button>
-      <button onClick={startPost}>Start Posting</button>
-      <button onClick={stop}>Stop</button>
+      <Button onClick={startGet} disabled={disabled}>{startLabel}</Button>
+      <Button onClick={startPost} disabled={disabled}>Start Posting</Button>
+      <Button onClick={stop} disabled={disabled}>Stop</Button>
     </div>
   )
 }
@@ -14,5 +15,6 @@ Controls.propTypes = {
   startGet: PropTypes.func.isRequired,
   startPost: PropTypes.func.isRequired,
   stop: PropTypes.func.isRequired,
-  startLabel: PropTypes.string
+  startLabel: PropTypes.string,
+  disabled: PropTypes.bool
 }

--- a/client/src/components/FiltersTab.jsx
+++ b/client/src/components/FiltersTab.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import Button from './ui/Button.jsx'
 
 export default function FiltersTab({ filters, setFilters }) {
   const [showForm, setShowForm] = useState(false)
@@ -87,11 +88,11 @@ export default function FiltersTab({ filters, setFilters }) {
           </select>
           <textarea value={instructions} onChange={e => setInstructions(e.target.value)} placeholder="Instructions" />
           <input type="file" multiple onChange={e => uploadFiles(Array.from(e.target.files))} />
-          <button onClick={create}>Save</button>
-          <button onClick={() => setShowForm(false)}>Cancel</button>
+          <Button onClick={create}>Save</Button>
+          <Button onClick={() => setShowForm(false)}>Cancel</Button>
         </div>
       ) : (
-        <button onClick={() => setShowForm(true)}>Create a filter</button>
+        <Button onClick={() => setShowForm(true)}>Create a filter</Button>
       )}
     </div>
   )

--- a/client/src/components/TGSources.jsx
+++ b/client/src/components/TGSources.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import PropTypes from 'prop-types'
+import Button from './ui/Button.jsx'
 
 export default function TGSources({ urls, addUrl, removeUrl }) {
   const [value, setValue] = useState('')
@@ -11,11 +12,11 @@ export default function TGSources({ urls, addUrl, removeUrl }) {
   return (
     <div className="tg-sources">
       <input value={value} onChange={e => setValue(e.target.value)} placeholder="https://t.me/s/channel" />
-      <button onClick={onAdd}>Add</button>
+      <Button onClick={onAdd}>Add</Button>
       <ul>
         {urls.map(u => (
           <li key={u}>
-            {u} <button onClick={() => removeUrl(u)}>x</button>
+            {u} <Button onClick={() => removeUrl(u)}>x</Button>
           </li>
         ))}
       </ul>

--- a/client/src/components/ui/Button.jsx
+++ b/client/src/components/ui/Button.jsx
@@ -1,0 +1,10 @@
+import PropTypes from 'prop-types'
+import './button.css'
+
+export default function Button({ className = '', ...props }) {
+  return <button className={`shadcn-btn ${className}`.trim()} {...props} />
+}
+
+Button.propTypes = {
+  className: PropTypes.string
+}

--- a/client/src/components/ui/button.css
+++ b/client/src/components/ui/button.css
@@ -1,0 +1,18 @@
+.shadcn-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  border: 1px solid #555;
+  background-color: #1f1f1f;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  transition: background-color 0.2s;
+}
+.shadcn-btn:hover {
+  background-color: #333;
+}
+.shadcn-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -51,6 +51,10 @@ button {
 button:hover {
   border-color: #646cff;
 }
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;

--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,7 @@ const { telegram_scraper } = require('telegram-scraper');
 const sources = require('./sources');
 const fs = require('fs');
 const multer = require('multer');
-const { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, resolveLink, sendApprovalRequest, answerCallback } = require('../bot');
+const { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, resolveLink, sendApprovalRequest, answerCallback, deleteMessage } = require('../bot');
 const { OpenAI, toFile } = require('openai');
 const { ProxyAgent } = require('undici');
 
@@ -114,6 +114,9 @@ botEvents.on('callback', async (query) => {
       awaitingPosts.delete(id);
       answerCallback(query.id, 'Cancelled').catch(() => {});
     }
+  }
+  if (query.message) {
+    deleteMessage(query.message.chat.id, query.message.message_id).catch(() => {});
   }
 });
 


### PR DESCRIPTION
## Summary
- remove approval message after buttons pressed via `deleteMessage`
- disable all controls until TG scraping options set
- add shadcn-style Button component and redesign UI

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863b2f67fd88325b31d598e0e874f3d