### PR TITLE
Fix TG Sources input layout

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -131,11 +131,14 @@
 }
 
 .channel-select,
-.filter-select,
-.tg-sources {
+.filter-select {
   margin-bottom: 1rem;
   display: flex;
   gap: 0.5rem;
+}
+
+.tg-sources {
+  margin-bottom: 1rem;
 }
 
 .tg-sources ul {

--- a/client/src/components/TGSources.jsx
+++ b/client/src/components/TGSources.jsx
@@ -11,8 +11,10 @@ export default function TGSources({ urls, addUrl, removeUrl }) {
   }
   return (
     <div className="tg-sources">
-      <input value={value} onChange={e => setValue(e.target.value)} placeholder="https://t.me/s/channel" />
-      <Button onClick={onAdd}>Add</Button>
+      <div className="tg-input">
+        <input value={value} onChange={e => setValue(e.target.value)} placeholder="https://t.me/s/channel" />
+        <Button onClick={onAdd}>Add</Button>
+      </div>
       <ul>
         {urls.map(u => (
           <li key={u}>


### PR DESCRIPTION
## Summary
- style `.tg-sources` as a block with flex row for the input only
- wrap source input and button in `.tg-input` container

## Testing
- `npm run install-all`
- `./node_modules/.bin/vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6863b83d292c83259debecd8b3861722