### PR TITLE
Add per-instance posting channel support

### DIFF
--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -6,6 +6,8 @@ export default function AdminTab({ instanceId }) {
   const [username, setUsername] = useState('')
   const [users, setUsers] = useState([])
   const [queue, setQueue] = useState([])
+  const [channelLink, setChannelLink] = useState('')
+  const [channels, setChannels] = useState([])
 
   const load = () => {
     fetch(`http://localhost:3001/api/instances/${instanceId}/approvers`)
@@ -15,6 +17,13 @@ export default function AdminTab({ instanceId }) {
     fetch('http://localhost:3001/api/awaiting')
       .then(r => r.json())
       .then(data => setQueue(Array.isArray(data) ? data : []))
+      .catch(() => {})
+    fetch(`http://localhost:3001/api/instances/${instanceId}/post-channels`)
+      .then(r => r.json())
+      .then(data => {
+        const arr = Object.entries(data).map(([cid, info]) => ({ id: cid, ...info }))
+        setChannels(arr)
+      })
       .catch(() => {})
   }
 
@@ -32,6 +41,18 @@ export default function AdminTab({ instanceId }) {
       body: JSON.stringify({ username: username.trim() })
     }).then(() => {
       setUsername('')
+      load()
+    }).catch(() => {})
+  }
+
+  const addPostChannel = () => {
+    if (!channelLink.trim()) return
+    fetch(`http://localhost:3001/api/instances/${instanceId}/post-channels`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ link: channelLink.trim() })
+    }).then(() => {
+      setChannelLink('')
       load()
     }).catch(() => {})
   }
@@ -61,6 +82,16 @@ export default function AdminTab({ instanceId }) {
       <ul>
         {users.map(u => (
           <li key={u}><span>{u}</span> <Button onClick={() => remove(u)}>x</Button></li>
+        ))}
+      </ul>
+      <h4>Posting Channels</h4>
+      <div className="tg-input">
+        <input value={channelLink} onChange={e => setChannelLink(e.target.value)} placeholder="https://t.me/channel" />
+        <Button onClick={addPostChannel}>Add posting channel</Button>
+      </div>
+      <ul>
+        {channels.map(c => (
+          <li key={c.id}>{c.username || c.title}</li>
         ))}
       </ul>
       <h4>Awaiting Approval</h4>

--- a/server/index.js
+++ b/server/index.js
@@ -12,7 +12,19 @@ const { marked } = require('marked');
 const { telegram_scraper } = require('telegram-scraper');
 const fs = require('fs');
 const multer = require('multer');
-const { listChannels, sendMessage, sendPhoto, sendVideo, botEvents, resolveLink, sendApprovalRequest, answerCallback, deleteMessage } = require('../bot');
+const {
+  listChannels,
+  listInstanceChannels,
+  addChannel,
+  sendMessage,
+  sendPhoto,
+  sendVideo,
+  botEvents,
+  resolveLink,
+  sendApprovalRequest,
+  answerCallback,
+  deleteMessage
+} = require('../bot');
 const { OpenAI, toFile } = require('openai');
 const { ProxyAgent } = require('undici');
 
@@ -404,6 +416,22 @@ app.delete('/api/instances/:id/approvers', (req, res) => {
     saveInstances();
   }
   res.json({ ok: true });
+});
+
+app.get('/api/instances/:id/post-channels', (req, res) => {
+  res.json(listInstanceChannels(req.params.id));
+});
+
+app.post('/api/instances/:id/post-channels', async (req, res) => {
+  try {
+    const { link } = req.body;
+    if (!link) return res.status(400).json({ error: 'link required' });
+    const info = await addChannel(req.params.id, link);
+    if (!info) return res.status(400).json({ error: 'failed to resolve' });
+    res.json(info);
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
 });
 
 app.get('/api/awaiting', (req, res) => {


### PR DESCRIPTION
## Summary
- support storing posting channels per instance in bot
- expose API endpoints to list and add post channels
- allow admin tab to manage posting channels

## Testing
- `npm test --prefix client`
- `npm run lint --prefix client` *(fails: no-undef errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863e3c6d7a88325ac38835a74c76262