### PR TITLE
Fix per-instance log streaming

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -141,38 +141,44 @@ async function addChannel(instanceId, link) {
   return { id, ...info };
 }
 
-async function sendMessage(channel, text, options = {}) {
+async function sendMessage(channel, text, options = {}, instanceId) {
   try {
     await bot.sendMessage(channel, text, { parse_mode: 'Markdown', ...options });
-    console.log('Sent message to', channel);
-    botEvents.emit('log', `Sent message to ${channel}`);
+    const msg = `Sent message to ${channel}`;
+    console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
   } catch (e) {
-    console.error('Failed to send message', channel, e.message);
-    botEvents.emit('log', `Failed to send message to ${channel}: ${e.message}`);
+    const msg = `Failed to send message to ${channel}: ${e.message}`;
+    console.error(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
     throw e;
   }
 }
 
-async function sendPhoto(channel, url, caption, options = {}) {
+async function sendPhoto(channel, url, caption, options = {}, instanceId) {
   try {
     await bot.sendPhoto(channel, url, { caption, parse_mode: 'Markdown', ...options });
-    console.log('Sent photo to', channel);
-    botEvents.emit('log', `Sent photo to ${channel}`);
+    const msg = `Sent photo to ${channel}`;
+    console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
   } catch (e) {
-    console.error('Failed to send photo', channel, e.message);
-    botEvents.emit('log', `Failed to send photo to ${channel}: ${e.message}`);
+    const msg = `Failed to send photo to ${channel}: ${e.message}`;
+    console.error(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
     throw e;
   }
 }
 
-async function sendVideo(channel, url, caption, options = {}) {
+async function sendVideo(channel, url, caption, options = {}, instanceId) {
   try {
     await bot.sendVideo(channel, url, { caption, parse_mode: 'Markdown', ...options });
-    console.log('Sent video to', channel);
-    botEvents.emit('log', `Sent video to ${channel}`);
+    const msg = `Sent video to ${channel}`;
+    console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
   } catch (e) {
-    console.error('Failed to send video', channel, e.message);
-    botEvents.emit('log', `Failed to send video to ${channel}: ${e.message}`);
+    const msg = `Failed to send video to ${channel}: ${e.message}`;
+    console.error(instanceId ? `[${instanceId}] ${msg}` : msg);
+    botEvents.emit('log', { message: msg, instanceId });
     throw e;
   }
 }

--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -88,7 +88,9 @@ export default function Instance({ id, title }) {
 
   const connect = (endpoint, params) => {
     if (es) return
-    const eventSource = new EventSource(`http://localhost:3001${endpoint}?${params}`)
+    const qs = new URLSearchParams(params)
+    qs.append('instanceId', id)
+    const eventSource = new EventSource(`http://localhost:3001${endpoint}?${qs.toString()}`)
     setEs(eventSource)
     eventSource.onmessage = (e) => {
       const item = JSON.parse(e.data)
@@ -199,14 +201,14 @@ export default function Instance({ id, title }) {
   }, [])
 
   useEffect(() => {
-    const esLogs = new EventSource('http://localhost:3001/api/logs')
+    const esLogs = new EventSource(`http://localhost:3001/api/logs?instanceId=${id}`)
     esLogs.onmessage = (e) => {
       const data = JSON.parse(e.data)
       console.log(`[${title}] ${data.message}`)
       setLogs(prev => [`[${title}] ${data.message}`, ...prev].slice(0, 50))
     }
     return () => esLogs.close()
-  }, [title])
+  }, [title, id])
 
   useEffect(() => {
     fetch('http://localhost:3001/api/channels')


### PR DESCRIPTION
## Summary
- include `instanceId` with log events and prefix console output
- filter `/api/logs` and `/api/tgnews` by instance id
- pass instance id through posting workflow
- handle instance id in Telegram sending helpers
- connect client EventSource with instance id parameter

## Testing
- `npm test --prefix client -- --run`
- `npm run lint --prefix client` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863e9d09e308325984503d744eb5bf2