### PR TITLE
Add configurable filter scores with modal details

### DIFF
--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -29,6 +29,7 @@ export default function Instance({ id, title }) {
   const channelsRef = useRef(selectedChannels)
   const tabRef = useRef(tab)
   const filterRef = useRef(selectedFilter)
+  const filtersRef = useRef(filters)
   const [, forceTick] = useState(0)
   const controlsDisabled = !selectedChannels.length || selectedFilter === 'none'
 
@@ -86,6 +87,10 @@ export default function Instance({ id, title }) {
     filterRef.current = selectedFilter
   }, [selectedFilter])
 
+  useEffect(() => {
+    filtersRef.current = filters
+  }, [filters])
+
   const connect = (endpoint, params) => {
     if (es) return
     const qs = new URLSearchParams(params)
@@ -119,7 +124,9 @@ export default function Instance({ id, title }) {
           })
             .then(r => r.json())
             .then(data => {
-              if (data.score > 7) send(data.score)
+              const fobj = filtersRef.current.find(f => f.id === fid)
+              const threshold = fobj && typeof fobj.min_score === 'number' ? fobj.min_score : 7
+              if (data.score > threshold) send(data.score)
             })
             .catch(() => {})
         } else {

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,0 +1,22 @@
+import PropTypes from 'prop-types'
+import './modal.css'
+
+export default function Modal({ open, onClose, children }) {
+  if (!open) return null
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div className="modal" onClick={e => e.stopPropagation()}>
+        {children}
+        <div className="modal-actions">
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+Modal.propTypes = {
+  open: PropTypes.bool,
+  onClose: PropTypes.func,
+  children: PropTypes.node
+}

--- a/client/src/components/ui/modal.css
+++ b/client/src/components/ui/modal.css
@@ -1,0 +1,25 @@
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: #2b2b2b;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 100%;
+}
+
+.modal-actions {
+  margin-top: 1rem;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- allow server to store `min_score` for filters
- expose filter update endpoint
- show filter details in the UI via modal and make score editable
- send posts only when they meet filter's min score

## Testing
- `npm test --silent --prefix server` *(fails: Error: no test specified)*
- `npm test --silent --prefix client` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865489ed4048325a6eeeea3dc83d7e0