### PR TITLE
Add instance deletion UI

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -28,6 +28,10 @@ export default function App() {
     setTitle('')
   }
 
+  const removeInstance = (instId) => {
+    setInstances(prev => prev.filter(i => i.id !== instId))
+  }
+
   return (
     <div className="App">
       <h2>Instances</h2>
@@ -36,7 +40,12 @@ export default function App() {
         <Button onClick={add}>Add new instance</Button>
       </div>
       {instances.map(inst => (
-        <Instance key={inst.id} id={inst.id} title={inst.title} />
+        <Instance
+          key={inst.id}
+          id={inst.id}
+          title={inst.title}
+          onDelete={() => removeInstance(inst.id)}
+        />
       ))}
     </div>
   )

--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -12,7 +12,7 @@ import Button from './components/ui/Button.jsx'
 
 import './App.css'
 
-export default function Instance({ id, title }) {
+export default function Instance({ id, title, onDelete }) {
   const [news, setNews] = useState([])
   const [es, setEs] = useState(null)
   const [channels, setChannels] = useState([])
@@ -248,7 +248,7 @@ export default function Instance({ id, title }) {
           <FilterSelect filters={filters} selected={selectedFilter} setSelected={setSelectedFilter} />
         </>
       ) : tab === 'admin' ? (
-        <AdminTab instanceId={id} />
+        <AdminTab instanceId={id} onDelete={() => onDelete && onDelete(id)} />
       ) : (
         <FiltersTab filters={filters} setFilters={setFilters} />
       )}

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -1,13 +1,15 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from './ui/Button.jsx'
+import Modal from './ui/Modal.jsx'
 
-export default function AdminTab({ instanceId }) {
+export default function AdminTab({ instanceId, onDelete }) {
   const [username, setUsername] = useState('')
   const [users, setUsers] = useState([])
   const [queue, setQueue] = useState([])
   const [channelLink, setChannelLink] = useState('')
   const [channels, setChannels] = useState([])
+  const [confirmDelete, setConfirmDelete] = useState(false)
 
   const load = () => {
     fetch(`http://localhost:3001/api/instances/${instanceId}/approvers`)
@@ -73,6 +75,15 @@ export default function AdminTab({ instanceId }) {
       .then(load).catch(() => {})
   }
 
+  const doDelete = () => {
+    fetch(`http://localhost:3001/api/instances/${instanceId}`, { method: 'DELETE' })
+      .then(() => {
+        setConfirmDelete(false)
+        if (onDelete) onDelete()
+      })
+      .catch(() => setConfirmDelete(false))
+  }
+
   return (
     <div className="admin-tab">
       <div className="tg-input">
@@ -106,10 +117,19 @@ export default function AdminTab({ instanceId }) {
           </li>
         ))}
       </ul>
+      <Button onClick={() => setConfirmDelete(true)}>Delete instance</Button>
+      <Modal
+        open={confirmDelete}
+        onClose={() => setConfirmDelete(false)}
+        actions={<Button onClick={doDelete}>Delete</Button>}
+      >
+        Are you sure you want to delete this instance?
+      </Modal>
     </div>
   )
 }
 
 AdminTab.propTypes = {
-  instanceId: PropTypes.string.isRequired
+  instanceId: PropTypes.string.isRequired,
+  onDelete: PropTypes.func
 }


### PR DESCRIPTION
## Summary
- add confirmation modal in admin tab for deleting instance
- update Instance and App components to support deletion

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68655092b0308325bb16e8ac64d2e9c3