### PR TITLE
Fix Express 5 wildcard route

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -743,7 +743,8 @@ app.get('/api/tgnews', async (req, res) => {
 });
 
 if (fs.existsSync(CLIENT_DIST)) {
-  app.get('*', (req, res, next) => {
+  // Express@5 requires a named wildcard parameter
+  app.get('/*rest', (req, res, next) => {
     if (req.path.startsWith('/api') || req.path.startsWith('/docs')) return next();
     res.sendFile(path.join(CLIENT_DIST, 'index.html'));
   });


### PR DESCRIPTION
## Summary
- update catch‑all route to use a named wildcard so that Express 5 doesn't throw a `path-to-regexp` error

## Testing
- `node -e "const ptr=require('path-to-regexp');console.log(ptr.pathToRegexp('/*rest'));"`


------
https://chatgpt.com/codex/tasks/task_e_686701048e7c8325a8f9b3f402e5458d