### PR TITLE
Improve localtunnel instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,6 @@ curl -F attachments=@notes.txt \
 
 You can quickly share the app while your laptop is running using [localtunnel](https://github.com/localtunnel/localtunnel).
 Run `npm run share` and keep the terminal open. The command builds the React client, starts the Node server and prints a temporary public URL.
-Open this URL on your phone to test the app.
+If the `lt` command is not recognized or prints unreadable text, make sure the project dependencies are installed with `npm run install-all`. You can also start the tunnel manually via `npx localtunnel --port 3001`.
+Open the printed URL on your phone to test the app.
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "install-all": "npm install --prefix server && npm install --prefix client",
     "start": "concurrently \"npm start --prefix server\" \"npm run dev --prefix client\"",
-    "share": "npm run build --prefix client && concurrently \"npm start --prefix server\" \"lt --port 3001\""
+    "share": "npm run build --prefix client && concurrently \"npm start --prefix server\" \"npx localtunnel --port 3001\""
   },
   "dependencies": {
     "dotenv": "^16.4.5",


### PR DESCRIPTION
## Summary
- clarify how to start localtunnel in README
- make the `share` script explicitly call `npx localtunnel`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68670304b4148325af874122a2a5e0e0