### PR TITLE
Add login navigation and user management page

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -7,6 +7,13 @@
   justify-content: space-between;
   align-items: center;
 }
+.nav {
+  display: flex;
+  gap: 0.5rem;
+}
+.nav .active {
+  font-weight: bold;
+}
 .sources {
   border-collapse: collapse;
   margin-bottom: 1rem;

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import Instance from './Instance.jsx'
+import Users from './Users.jsx'
 import Button from './components/ui/Button.jsx'
 import Login from './Login.jsx'
 import './App.css'
@@ -8,6 +9,7 @@ export default function App() {
   const [title, setTitle] = useState('')
   const [instances, setInstances] = useState([])
   const [user, setUser] = useState(null)
+  const [page, setPage] = useState('dashboard')
 
   const loadUser = () => {
     fetch('/api/me')
@@ -16,7 +18,9 @@ export default function App() {
       .catch(() => setUser(null))
   }
 
-  useEffect(loadUser, [])
+  useEffect(() => {
+    if (localStorage.getItem('access-token')) loadUser()
+  }, [])
 
   useEffect(() => {
     if (!user) return
@@ -47,27 +51,39 @@ export default function App() {
   if (!user) return <Login onLogin={loadUser} />
 
   const logout = () => {
-    fetch('/api/logout').finally(() => setUser(null))
+    fetch('/api/logout').finally(() => {
+      localStorage.removeItem('access-token')
+      setUser(null)
+    })
   }
 
   return (
     <div className="App">
       <div className="header">
-        <h2>Instances</h2>
+        <div className="nav">
+          <Button onClick={() => setPage('dashboard')} className={page === 'dashboard' ? 'active' : ''}>Dashboard</Button>
+          <Button onClick={() => setPage('users')} className={page === 'users' ? 'active' : ''}>Users</Button>
+        </div>
         <Button onClick={logout}>Logout</Button>
       </div>
-      <div className="tg-input">
-        <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Instance title" />
-        <Button onClick={add}>Add new instance</Button>
-      </div>
-      {instances.map(inst => (
-        <Instance
-          key={inst.id}
-          id={inst.id}
-          title={inst.title}
-          onDelete={() => removeInstance(inst.id)}
-        />
-      ))}
+      {page === 'dashboard' ? (
+        <>
+          <div className="tg-input">
+            <input value={title} onChange={e => setTitle(e.target.value)} placeholder="Instance title" />
+            <Button onClick={add}>Add new instance</Button>
+          </div>
+          {instances.map(inst => (
+            <Instance
+              key={inst.id}
+              id={inst.id}
+              title={inst.title}
+              onDelete={() => removeInstance(inst.id)}
+            />
+          ))}
+        </>
+      ) : (
+        <Users />
+      )}
     </div>
   )
 }

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -16,7 +16,10 @@ export default function Login({ onLogin }) {
         if (!r.ok) throw new Error('fail')
         return r.json()
       })
-      .then(() => onLogin && onLogin())
+      .then(() => {
+        localStorage.setItem('access-token', '1')
+        onLogin && onLogin()
+      })
       .catch(() => window.alert('Invalid credentials'))
   }
   return (

--- a/client/src/Users.jsx
+++ b/client/src/Users.jsx
@@ -1,0 +1,51 @@
+import { useState, useEffect } from 'react'
+import Button from './components/ui/Button.jsx'
+
+export default function Users() {
+  const [login, setLogin] = useState('')
+  const [password, setPassword] = useState('')
+  const [accounts, setAccounts] = useState([])
+
+  const load = () => {
+    fetch('/api/users')
+      .then(r => r.json())
+      .then(data => setAccounts(Array.isArray(data) ? data : []))
+      .catch(() => {})
+  }
+
+  useEffect(load, [])
+
+  const addUser = () => {
+    if (!login.trim() || !password.trim()) return
+    fetch('/api/users', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ login: login.trim(), password: password.trim() })
+    }).then(() => {
+      setLogin('')
+      setPassword('')
+      load()
+    }).catch(() => {})
+  }
+
+  const deleteUser = (name) => {
+    fetch(`/api/users/${name}`, { method: 'DELETE' })
+      .then(load).catch(() => {})
+  }
+
+  return (
+    <div className="users-page">
+      <h3>Users</h3>
+      <div className="tg-input">
+        <input value={login} onChange={e => setLogin(e.target.value)} placeholder="login" />
+        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="password" />
+        <Button onClick={addUser}>Add User</Button>
+      </div>
+      <ul>
+        {accounts.map(u => (
+          <li key={u}><span>{u}</span> <Button onClick={() => deleteUser(u)}>x</Button></li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -5,10 +5,7 @@ import Modal from './ui/Modal.jsx'
 
 export default function AdminTab({ instanceId, onDelete }) {
   const [username, setUsername] = useState('')
-  const [login, setLogin] = useState('')
-  const [password, setPassword] = useState('')
   const [approvers, setApprovers] = useState([])
-  const [accounts, setAccounts] = useState([])
   const [queue, setQueue] = useState([])
   const [channelLink, setChannelLink] = useState('')
   const [channels, setChannels] = useState([])
@@ -18,10 +15,6 @@ export default function AdminTab({ instanceId, onDelete }) {
     fetch(`/api/instances/${instanceId}/approvers`)
       .then(r => r.json())
       .then(data => setApprovers(Array.isArray(data) ? data : []))
-      .catch(() => {})
-    fetch('/api/users')
-      .then(r => r.json())
-      .then(data => setAccounts(Array.isArray(data) ? data : []))
       .catch(() => {})
     fetch('/api/awaiting')
       .then(r => r.json())
@@ -66,23 +59,6 @@ export default function AdminTab({ instanceId, onDelete }) {
     }).catch(() => {})
   }
 
-  const addUser = () => {
-    if (!login.trim() || !password.trim()) return
-    fetch('/api/users', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ login: login.trim(), password: password.trim() })
-    }).then(() => {
-      setLogin('')
-      setPassword('')
-      load()
-    }).catch(() => {})
-  }
-
-  const deleteUser = (name) => {
-    fetch(`/api/users/${name}`, { method: 'DELETE' })
-      .then(load).catch(() => {})
-  }
 
   const remove = (name) => {
     fetch(`/api/instances/${instanceId}/approvers?username=${name}`, {
@@ -118,17 +94,6 @@ export default function AdminTab({ instanceId, onDelete }) {
       <ul>
         {approvers.map(u => (
           <li key={u}><span>{u}</span> <Button onClick={() => remove(u)}>x</Button></li>
-        ))}
-      </ul>
-      <h4>Users</h4>
-      <div className="tg-input">
-        <input value={login} onChange={e => setLogin(e.target.value)} placeholder="login" />
-        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="password" />
-        <Button onClick={() => addUser()}>Add User</Button>
-      </div>
-      <ul>
-        {accounts.map(u => (
-          <li key={u}><span>{u}</span> <Button onClick={() => deleteUser(u)}>x</Button></li>
         ))}
       </ul>
       <h4>Posting Channels</h4>


### PR DESCRIPTION
## Summary
- add `Users` page to manage accounts
- move user list from instance administration
- add navigation header with Dashboard/Users/Logout
- persist a dummy access token in local storage after login

## Testing
- `./node_modules/.bin/vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686bf5225a888325ba258d068b85e285