### PR TITLE
Graceful startup without Telegram bot

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -13,15 +13,26 @@ export default function App() {
   const [page, setPage] = useState('dashboard')
 
   const loadUser = () => {
+    console.log('Fetching /api/me')
     apiFetch('/api/me')
       .then(r => (r.ok ? r.json() : null))
-      .then(data => setUser(data))
-      .catch(() => setUser(null))
+      .then(data => {
+        console.log('Current user', data)
+        setUser(data)
+      })
+      .catch(err => {
+        console.log('Failed loading user', err)
+        setUser(null)
+      })
   }
 
   useEffect(() => {
     if (localStorage.getItem('access-token')) loadUser()
   }, [])
+
+  useEffect(() => {
+    console.log('User state changed', user)
+  }, [user])
 
   useEffect(() => {
     if (!user) return
@@ -49,12 +60,17 @@ export default function App() {
     setInstances(prev => prev.filter(i => i.id !== instId))
   }
 
-  if (!user) return <Login onLogin={loadUser} />
+  if (!user) {
+    console.log('Displaying login page')
+    return <Login onLogin={loadUser} />
+  }
 
   const logout = () => {
+    console.log('Logging out')
     apiFetch('/api/logout').finally(() => {
       localStorage.removeItem('access-token')
       setUser(null)
+      console.log('Logged out')
     })
   }
 

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -7,6 +7,7 @@ export default function Login({ onLogin }) {
   const [password, setPassword] = useState('')
   const submit = (e) => {
     e.preventDefault()
+    console.log('Logging in as', login)
     fetch('/api/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -18,9 +19,13 @@ export default function Login({ onLogin }) {
       })
       .then(data => {
         localStorage.setItem('access-token', data.token)
+        console.log('Login success')
         onLogin && onLogin()
       })
-      .catch(() => window.alert('Invalid credentials'))
+      .catch(err => {
+        console.log('Login failed', err)
+        window.alert('Invalid credentials')
+      })
   }
   return (
     <form className="login-form" onSubmit={submit}>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -2,5 +2,6 @@ export default function apiFetch(url, options = {}) {
   const token = localStorage.getItem('access-token')
   const headers = { ...(options.headers || {}) }
   if (token) headers['Authorization'] = `Bearer ${token}`
+  console.log('apiFetch', url, options)
   return fetch(url, { ...options, headers })
 }


### PR DESCRIPTION
## Summary
- allow the server to start even when there is no `BOT_TOKEN`
- avoid OpenAI client initialization failure when `OPENAI_API_KEY` is missing
- add additional console logs for server authentication routes
- include client-side logs for login and logout workflow

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_68767536c62083259ff4faa001c895d0