### PR TITLE
Fix auth for SSE endpoints

### DIFF
--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -97,6 +97,8 @@ export default function Instance({ id, title, onDelete }) {
     if (es) return
     const qs = new URLSearchParams(params)
     qs.append('instanceId', id)
+    const token = localStorage.getItem('access-token')
+    if (token) qs.append('token', token)
     const eventSource = new EventSource(`${endpoint}?${qs.toString()}`)
     setEs(eventSource)
     eventSource.onmessage = (e) => {
@@ -210,7 +212,8 @@ export default function Instance({ id, title, onDelete }) {
   }, [])
 
   useEffect(() => {
-    const esLogs = new EventSource(`/api/logs?instanceId=${id}`)
+    const token = localStorage.getItem('access-token')
+    const esLogs = new EventSource(`/api/logs?instanceId=${id}${token ? `&token=${token}` : ''}`)
     esLogs.onmessage = (e) => {
       const data = JSON.parse(e.data)
       console.log(`[${title}] ${data.message}`)

--- a/server/index.js
+++ b/server/index.js
@@ -258,13 +258,19 @@ app.use(cors({ origin: '*' }));
 app.use((req, res, next) => {
   if (!req.path.startsWith('/api')) return next();
   if (req.path === '/api/login') return next();
+  let token;
   const auth = req.headers.authorization || '';
-  if (!auth.startsWith('Bearer ')) {
+  if (auth.startsWith('Bearer ')) {
+    token = auth.slice(7);
+  } else if (typeof req.query.token === 'string') {
+    token = req.query.token;
+  }
+  if (!token) {
     log('Missing auth token');
     return res.status(401).json({ error: 'unauthorized' });
   }
   try {
-    const user = jwt.verify(auth.slice(7), JWT_SECRET);
+    const user = jwt.verify(token, JWT_SECRET);
     req.user = user;
     log(`Authenticated ${user.login}`);
     next();


### PR DESCRIPTION
## Summary
- allow JWT token via query parameter
- include the auth token when creating EventSource connections

## Testing
- `npm test --prefix client`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68780c1f27a88325a88d0dc05fa0715b