### PR TITLE
Add HTML formatting and text-only approval option

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -143,7 +143,7 @@ async function addChannel(instanceId, link) {
 
 async function sendMessage(channel, text, options = {}, instanceId) {
   try {
-    await bot.sendMessage(channel, text, { parse_mode: 'Markdown', ...options });
+    await bot.sendMessage(channel, text, { parse_mode: 'HTML', ...options });
     const msg = `Sent message to ${channel}`;
     console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
     botEvents.emit('log', { message: msg, instanceId });
@@ -157,7 +157,7 @@ async function sendMessage(channel, text, options = {}, instanceId) {
 
 async function sendPhoto(channel, url, caption, options = {}, instanceId) {
   try {
-    await bot.sendPhoto(channel, url, { caption, parse_mode: 'Markdown', ...options });
+    await bot.sendPhoto(channel, url, { caption, parse_mode: 'HTML', ...options });
     const msg = `Sent photo to ${channel}`;
     console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
     botEvents.emit('log', { message: msg, instanceId });
@@ -171,7 +171,7 @@ async function sendPhoto(channel, url, caption, options = {}, instanceId) {
 
 async function sendVideo(channel, url, caption, options = {}, instanceId) {
   try {
-    await bot.sendVideo(channel, url, { caption, parse_mode: 'Markdown', ...options });
+    await bot.sendVideo(channel, url, { caption, parse_mode: 'HTML', ...options });
     const msg = `Sent video to ${channel}`;
     console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
     botEvents.emit('log', { message: msg, instanceId });
@@ -186,6 +186,7 @@ async function sendVideo(channel, url, caption, options = {}, instanceId) {
 async function sendApprovalRequest(userId, post) {
   const keyboard = { inline_keyboard: [[
     { text: 'Approve', callback_data: `approve:${post.id}` },
+    { text: 'Post without image', callback_data: `approve_text:${post.id}` },
     { text: 'Cancel', callback_data: `cancel:${post.id}` }
   ]] };
   const text = `Approve post to ${post.channel}?\n${post.text}`;

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -73,6 +73,11 @@ export default function AdminTab({ instanceId, onDelete }) {
       .then(load).catch(() => {})
   }
 
+  const postText = (id) => {
+    apiFetch(`/api/awaiting/${id}/text`, { method: 'POST' })
+      .then(load).catch(() => {})
+  }
+
   const cancel = (id) => {
     apiFetch(`/api/awaiting/${id}/cancel`, { method: 'POST' })
       .then(load).catch(() => {})
@@ -116,6 +121,7 @@ export default function AdminTab({ instanceId, onDelete }) {
             <div>{p.text?.slice(0, 100)}</div>
             {p.media && <img src={p.media} alt="" />}
             <Button onClick={() => approve(p.id)}>Approve</Button>
+            <Button onClick={() => postText(p.id)}>Post without image</Button>
             <Button onClick={() => cancel(p.id)}>Cancel</Button>
           </li>
         ))}

--- a/server/index.js
+++ b/server/index.js
@@ -239,6 +239,13 @@ botEvents.on('callback', async (query) => {
       await postToChannel(post);
       answerCallback(query.id, 'Approved').catch(() => {});
     }
+  } else if (action === 'approve_text') {
+    const post = awaitingPosts.get(id);
+    if (post) {
+      awaitingPosts.delete(id);
+      await postToChannel({ channel: post.channel, text: post.text, instanceId: post.instanceId });
+      answerCallback(query.id, 'Approved without image').catch(() => {});
+    }
   } else if (action === 'cancel') {
     if (awaitingPosts.has(id)) {
       awaitingPosts.delete(id);
@@ -605,6 +612,15 @@ app.post('/api/awaiting/:id/approve', async (req, res) => {
   if (!post) return res.status(404).json({ error: 'not found' });
   awaitingPosts.delete(id);
   await postToChannel(post);
+  res.json({ ok: true });
+});
+
+app.post('/api/awaiting/:id/text', async (req, res) => {
+  const { id } = req.params;
+  const post = awaitingPosts.get(id);
+  if (!post) return res.status(404).json({ error: 'not found' });
+  awaitingPosts.delete(id);
+  await postToChannel({ channel: post.channel, text: post.text, instanceId: post.instanceId });
   res.json({ ok: true });
 });
 


### PR DESCRIPTION
## Summary
- send all Telegram messages using HTML formatting
- offer 'Post without image' choice in approval UI and bot
- handle text-only approval in server API

## Testing
- `npm test --prefix client`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6878e40497fc832580c3ff6bb34fa196