### PR TITLE
Fix approve_image regex

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -229,7 +229,7 @@ loadUsers();
 fs.mkdirSync(path.join(__dirname, 'uploads'), { recursive: true });
 
 botEvents.on('callback', async (query) => {
-  const m = /^([a-z]+):(.+)$/.exec(query.data || '');
+  const m = /^([a-z_]+):(.+)$/.exec(query.data || '');
   if (!m) return;
   const [, action, id] = m;
   if (action === 'approve') {


### PR DESCRIPTION
## Summary
- allow underscores in callback actions so 'Approve with new image' works

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client`
- `npm run lint --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6878fda4a40483258f4a67ae570aa340