### PR TITLE
Fix MIME for OpenAI reference images

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -331,7 +331,7 @@ async function loadReferenceImage(name) {
   const filePath = path.join(__dirname, 'uploads', name);
   const { mime } = await detectMimeAndData(filePath);
   const ext = mime === 'image/png' ? '.png' : '.jpg';
-  return toFile(fs.createReadStream(filePath), name + ext);
+  return toFile(fs.createReadStream(filePath), name + ext, { type: mime });
 }
 
 async function generateImage(model, basePrompt, text, inst) {


### PR DESCRIPTION
## Summary
- preserve file MIME type when uploading reference images

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ed48100948325be2112985babd084