### PR TITLE
Fix Telegram image sending

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -155,9 +155,18 @@ async function sendMessage(channel, text, options = {}, instanceId) {
   }
 }
 
+function decodeDataUrl(dataUrl) {
+  const match = /^data:(.+);base64,(.*)$/.exec(dataUrl);
+  if (!match) return null;
+  return Buffer.from(match[2], 'base64');
+}
+
 async function sendPhoto(channel, url, caption, options = {}, instanceId) {
   try {
-    await bot.sendPhoto(channel, url, { caption, parse_mode: 'HTML', ...options });
+    const payload = typeof url === 'string' && url.startsWith('data:')
+      ? { source: decodeDataUrl(url) }
+      : url;
+    await bot.sendPhoto(channel, payload, { caption, parse_mode: 'HTML', ...options });
     const msg = `Sent photo to ${channel}`;
     console.log(instanceId ? `[${instanceId}] ${msg}` : msg);
     botEvents.emit('log', { message: msg, instanceId });


### PR DESCRIPTION
## Summary
- decode `data:` URLs before sending photos via Telegram

## Testing
- `node -c bot/index.js`

------
https://chatgpt.com/codex/tasks/task_e_687edadfea9c8325a8eb67e4ab53485f