### PR TITLE
Track OpenAI token usage and cost

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -209,7 +209,8 @@ async function sendApprovalRequest(userId, post) {
     { text: 'Approve with new image', callback_data: `approve_image:${post.id}` },
     { text: 'Cancel', callback_data: `cancel:${post.id}` }
   ]] };
-  const text = `Approve post to ${post.channel}?\n${post.text}`;
+  const costText = post.cost != null ? `\nCost so far: $${post.cost.toFixed(4)}` : '';
+  const text = `Approve post to ${post.channel}?${costText}\n${post.text}`;
   if (post.media) {
     if (post.media.toLowerCase().endsWith('.mp4')) {
       await sendVideo(userId, post.media, text, { reply_markup: keyboard });


### PR DESCRIPTION
## Summary
- track token/image prices and accumulate usage
- record tokens from filter evaluation and author rewrites
- track image generation cost
- show cost in Telegram approval messages
- persist simple cost log

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ee626252c832595511f6a57a5831a