### PR TITLE
Prevent autoposting when no approver active

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Send messages or media to a Telegram channel. The endpoint accepts a JSON body:
 }
 ```
 
+At least one approver must have started `/start_approving`.
+Otherwise the endpoint responds with `{ "error": "no active approvers" }` and
+nothing is posted.
+
 When `media` is provided, the server sends a photo or video to the channel. If
 the URL ends with `.mp4` a video is sent, otherwise a photo. When only `text` is
 present it falls back to a regular message.

--- a/server/index.js
+++ b/server/index.js
@@ -787,6 +787,9 @@ app.post('/api/post', async (req, res) => {
     const { channel, text, media, instanceId } = req.body;
     if (!channel) return res.status(400).json({ error: 'channel required' });
     if (!text && !media) return res.status(400).json({ error: 'text or media required' });
+    if (activeApprovers.size === 0) {
+      return res.status(400).json({ error: 'no active approvers' });
+    }
     const inst = instances.find(i => i.id === instanceId);
     const approverList = inst && Array.isArray(inst.approvers) ? inst.approvers : approvers;
     const targets = [];


### PR DESCRIPTION
## Summary
- block posting through `/api/post` when no approver has started approving
- document this requirement in the README

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm install --prefix client`
- `npm test --prefix client` *(all tests pass, watch mode cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687ed89adecc8325a8132d27e7c21d0a