### PR TITLE
Fix token cost tracking and expand pricing

### DIFF
--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -127,6 +127,7 @@ export default function Instance({ id, title, onDelete }) {
       const item = JSON.parse(e.data)
       setNews(prev => [item, ...prev])
       if (postingRef.current) {
+        const postId = `${Date.now()}-${Math.random().toString(16).slice(2)}`
         const base = tabRef.current === 'tg'
           ? `${item.text || item.title}\n${item.url}`
           : `*${item.title}*\n${item.url}`
@@ -136,7 +137,7 @@ export default function Instance({ id, title, onDelete }) {
             apiFetch('/api/post', {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ channel: ch, text, media, instanceId: id })
+              body: JSON.stringify({ channel: ch, text, media, instanceId: id, id: postId })
             }).catch(() => {})
           })
         }
@@ -145,7 +146,7 @@ export default function Instance({ id, title, onDelete }) {
           apiFetch(`/api/filters/${fid}/evaluate`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ text: base })
+            body: JSON.stringify({ text: base, post_id: postId })
           })
             .then(r => r.json())
             .then(data => {
@@ -157,7 +158,7 @@ export default function Instance({ id, title, onDelete }) {
                   apiFetch(`/api/authors/${aid}/rewrite`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ text: base })
+                    body: JSON.stringify({ text: base, post_id: postId })
                   })
                     .then(r => r.json())
                     .then(resp => send(resp.text))
@@ -174,7 +175,7 @@ export default function Instance({ id, title, onDelete }) {
             apiFetch(`/api/authors/${aid}/rewrite`, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ text: base })
+              body: JSON.stringify({ text: base, post_id: postId })
             })
               .then(r => r.json())
               .then(resp => send(resp.text))

--- a/server/index.js
+++ b/server/index.js
@@ -93,6 +93,8 @@ const activeApprovers = new Map(); // id -> username
 // Track token and image costs per post
 const TOKEN_PRICES = {
   'gpt-4o': 0.005,
+  'o3': 0.005,
+  'o4': 0.005,
   'gpt-4': 0.03,
   'gpt-4-turbo': 0.01,
   'gpt-3.5-turbo': 0.0005,
@@ -102,6 +104,8 @@ const IMAGE_PRICES = {
   'dall-e-3': 0.04,
   'dall-e-2': 0.02,
   'gpt-image-1': 0.01,
+  'o3': 0.01,
+  'o4': 0.01,
   'gpt-4o': 0.01,
   default: 0.02
 };
@@ -869,7 +873,7 @@ function postToChannel({ channel, text, media, instanceId }) {
 
 app.post('/api/post', async (req, res) => {
   try {
-    const { channel, text, media, instanceId } = req.body;
+    const { channel, text, media, instanceId, id: customId } = req.body;
     if (!channel) return res.status(400).json({ error: 'channel required' });
     if (!text && !media) return res.status(400).json({ error: 'text or media required' });
     const inst = instances.find(i => i.id === instanceId);
@@ -879,7 +883,7 @@ app.post('/api/post', async (req, res) => {
       if (approverList.includes(name)) targets.push(uid);
     }
     if (targets.length) {
-      const id = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const id = customId || `${Date.now()}-${Math.random().toString(16).slice(2)}`;
       const info = { id, channel, text, media, instanceId, tokens: 0, images: 0, cost: 0 };
       awaitingPosts.set(id, info);
       for (const uid of targets) {


### PR DESCRIPTION
## Summary
- include optional post IDs when evaluating and rewriting posts
- allow supplying a custom ID when posting so token costs can be tracked
- handle pricing for new `o3` and `o4` model series

## Testing
- `npm test --silent`
- `npm --prefix server test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687eeaf186488325969d460d32a672df