### PR TITLE
Add official image options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ curl -F title=News -F model=gpt-4o \
 
 Upload files first using the `/api/vector-stores` endpoint which creates a vector store. Pass the returned `vector_store_id` when creating the filter. When creation succeeds the API returns the filter id which can later be used to evaluate posts via `/api/filters/<id>/evaluate`.
 
+### Image generation settings
+
+The Administration tab lets you pick the image model, quality, and resolution. The available quality levels are **low**, **medium**, and **high** while the supported resolutions are **1024×1024**, **1024×1536**, and **1536×1024**. These options match the [OpenAI image API documentation](https://platform.openai.com/docs/api-reference/images/create).
+
 Additional knowledge can be added later using `/api/filters/<id>/files`:
 
 ```bash

--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -32,6 +32,8 @@ export default function Instance({ id, title, onDelete }) {
   const [selectedAuthor, setSelectedAuthor] = useState('none')
   const [imageModel, setImageModel] = useState('dall-e-3')
   const [imagePrompt, setImagePrompt] = useState('Create an image for a Telegram post based on the following text: {postText}. The image should have a stylish, minimalistic design with modern, fashionable gradients.')
+  const [imageQuality, setImageQuality] = useState('medium')
+  const [imageSize, setImageSize] = useState('1024x1024')
   const [loaded, setLoaded] = useState(false)
   const postingRef = useRef(posting)
   const channelsRef = useRef(selectedChannels)
@@ -55,6 +57,8 @@ export default function Instance({ id, title, onDelete }) {
         setSelectedAuthor(data.author || 'none')
         setImageModel(data.imageModel || 'dall-e-3')
         setImagePrompt(data.imagePrompt || 'Create an image for a Telegram post based on the following text: {postText}. The image should have a stylish, minimalistic design with modern, fashionable gradients.')
+        setImageQuality(data.imageQuality || 'medium')
+        setImageSize(data.imageSize || '1024x1024')
       })
       .catch(() => {})
       .finally(() => setLoaded(true))
@@ -70,14 +74,16 @@ export default function Instance({ id, title, onDelete }) {
       filter: selectedFilter,
       author: selectedAuthor,
       imageModel,
-      imagePrompt
+      imagePrompt,
+      imageQuality,
+      imageSize
     }
     apiFetch(`/api/instances/${id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body)
     }).catch(() => {})
-  }, [id, loaded, selectedChannels, mode, tab, tgUrls, selectedFilter, selectedAuthor, imageModel, imagePrompt])
+  }, [id, loaded, selectedChannels, mode, tab, tgUrls, selectedFilter, selectedAuthor, imageModel, imagePrompt, imageQuality, imageSize])
 
   const addTgUrl = (url) => {
     setTgUrls(prev => prev.includes(url) ? prev : [...prev, url])
@@ -317,6 +323,10 @@ export default function Instance({ id, title, onDelete }) {
           setImageModel={setImageModel}
           imagePrompt={imagePrompt}
           setImagePrompt={setImagePrompt}
+          imageQuality={imageQuality}
+          setImageQuality={setImageQuality}
+          imageSize={imageSize}
+          setImageSize={setImageSize}
         />
       ) : tab === 'filters' ? (
         <FiltersTab filters={filters} setFilters={setFilters} />

--- a/client/src/components/AdminTab.jsx
+++ b/client/src/components/AdminTab.jsx
@@ -5,8 +5,12 @@ import Modal from './ui/Modal.jsx'
 import apiFetch from '../api.js'
 
 const IMAGE_MODELS = ['dall-e-3', 'dall-e-2', 'gpt-image-1', 'gpt-4o']
+// official values from OpenAI docs
+const IMAGE_QUALITIES = ['low', 'medium', 'high']
+const IMAGE_SIZES = ['1024x1024', '1024x1536', '1536x1024']
+const DALL_E2_SIZES = ['256x256', '512x512', '1024x1024']
 
-export default function AdminTab({ instanceId, onDelete, imageModel, setImageModel, imagePrompt, setImagePrompt }) {
+export default function AdminTab({ instanceId, onDelete, imageModel, setImageModel, imagePrompt, setImagePrompt, imageQuality, setImageQuality, imageSize, setImageSize }) {
   const [username, setUsername] = useState('')
   const [approvers, setApprovers] = useState([])
   const [queue, setQueue] = useState([])
@@ -81,7 +85,7 @@ export default function AdminTab({ instanceId, onDelete, imageModel, setImageMod
   }
 
   const approveImage = (id) => {
-    const body = { model: imageModel, prompt: imagePrompt }
+    const body = { model: imageModel, prompt: imagePrompt, quality: imageQuality, size: imageSize }
     apiFetch(`/api/awaiting/${id}/image`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -168,6 +172,24 @@ export default function AdminTab({ instanceId, onDelete, imageModel, setImageMod
         </select>
       </div>
       <div className="tg-input">
+        <select value={imageQuality} onChange={e => setImageQuality(e.target.value)}>
+          {IMAGE_QUALITIES.map(q => (
+            <option key={q} value={q}>{q}</option>
+          ))}
+        </select>
+      </div>
+      <div className="tg-input">
+        <select value={imageSize} onChange={e => setImageSize(e.target.value)}>
+          {(
+            imageModel === 'dall-e-2'
+              ? DALL_E2_SIZES
+              : IMAGE_SIZES
+          ).map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+      <div className="tg-input">
         <textarea
           value={imagePrompt}
           onChange={e => setImagePrompt(e.target.value)}
@@ -208,5 +230,9 @@ AdminTab.propTypes = {
   imageModel: PropTypes.string.isRequired,
   setImageModel: PropTypes.func.isRequired,
   imagePrompt: PropTypes.string.isRequired,
-  setImagePrompt: PropTypes.func.isRequired
+  setImagePrompt: PropTypes.func.isRequired,
+  imageQuality: PropTypes.string.isRequired,
+  setImageQuality: PropTypes.func.isRequired,
+  imageSize: PropTypes.string.isRequired,
+  setImageSize: PropTypes.func.isRequired
 }


### PR DESCRIPTION
## Summary
- use the documented size and quality lists for image models
- simplify dropdowns to always show the official qualities and resolutions
- include quality in every image request

## Testing
- `npm test --prefix client -- --run`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687ef3cfb6148325aba895e3b34f6de7