### PR TITLE
Remove token cost features and enhance TG source display

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -209,8 +209,7 @@ async function sendApprovalRequest(userId, post) {
     { text: 'Approve with new image', callback_data: `approve_image:${post.id}` },
     { text: 'Cancel', callback_data: `cancel:${post.id}` }
   ]] };
-  const costText = post.cost != null ? `\nCost so far: $${post.cost.toFixed(4)}` : '';
-  const text = `Approve post to ${post.channel}?${costText}\n${post.text}`;
+  const text = `Approve post to ${post.channel}?\n${post.text}`;
   if (post.media) {
     if (post.media.toLowerCase().endsWith('.mp4')) {
       await sendVideo(userId, post.media, text, { reply_markup: keyboard });

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -161,7 +161,24 @@
 }
 
 .tg-sources li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
   margin-bottom: 0.25rem;
+}
+
+.tg-sources li img {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.tg-sources li button {
+  margin-left: auto;
+  background-color: #550000;
+  border-color: #550000;
+  color: #fff;
 }
 
 .tg-input {

--- a/client/src/components/TGSources.jsx
+++ b/client/src/components/TGSources.jsx
@@ -1,9 +1,25 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from './ui/Button.jsx'
 
 export default function TGSources({ urls, addUrl, removeUrl }) {
   const [value, setValue] = useState('')
+  const [info, setInfo] = useState({})
+
+  useEffect(() => {
+    for (const url of urls) {
+      if (!info[url]) {
+        fetch(`/api/tg-source-info?url=${encodeURIComponent(url)}`)
+          .then(r => r.ok ? r.json() : null)
+          .then(data => {
+            if (data && data.title) {
+              setInfo(prev => ({ ...prev, [url]: data }))
+            }
+          })
+          .catch(() => {})
+      }
+    }
+  }, [urls])
   const onAdd = () => {
     if (!value.trim()) return
     addUrl(value.trim())
@@ -16,11 +32,16 @@ export default function TGSources({ urls, addUrl, removeUrl }) {
         <Button onClick={onAdd}>Add</Button>
       </div>
       <ul>
-        {urls.map(u => (
-          <li key={u}>
-            {u} <Button onClick={() => removeUrl(u)}>x</Button>
-          </li>
-        ))}
+        {urls.map(u => {
+          const i = info[u] || {}
+          return (
+            <li key={u}>
+              {i.image && <img src={i.image} alt="" />}
+              <span>{i.title || u}</span>
+              <Button onClick={() => removeUrl(u)}>Delete</Button>
+            </li>
+          )
+        })}
       </ul>
     </div>
   )


### PR DESCRIPTION
## Summary
- clean up server code by removing token price tracking and cost accounting
- update approval request messages in the bot
- show Telegram source avatar and title instead of raw link
- style new source entries with a red Delete button
- expose `/api/tg-source-info` for channel metadata

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_687f89e4b2348325958b30bade8b5579