### PR TITLE
Add channel details modal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -172,6 +172,11 @@
   height: 24px;
   border-radius: 50%;
   object-fit: cover;
+  cursor: pointer;
+}
+
+.tg-sources li span {
+  cursor: pointer;
 }
 
 .tg-sources li button {

--- a/client/src/components/TGSources.jsx
+++ b/client/src/components/TGSources.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from './ui/Button.jsx'
+import Modal from './ui/Modal.jsx'
 import apiFetch from '../api.js'
 
 export default function TGSources({ urls, addUrl, removeUrl }) {
   const [value, setValue] = useState('')
   const [info, setInfo] = useState({})
+  const [open, setOpen] = useState(null)
 
   useEffect(() => {
     for (const url of urls) {
@@ -37,13 +39,28 @@ export default function TGSources({ urls, addUrl, removeUrl }) {
           const i = info[u] || {}
           return (
             <li key={u}>
-              {i.image && <img src={i.image} alt="" />}
-              <span>{i.title || u}</span>
+              {i.image && <img src={i.image} alt="" onClick={() => setOpen(u)} />}
+              <span onClick={() => setOpen(u)}>{i.title || u}</span>
               <Button onClick={() => removeUrl(u)}>Delete</Button>
             </li>
           )
         })}
       </ul>
+      <Modal
+        open={!!open}
+        onClose={() => setOpen(null)}
+        actions={open && (
+          <Button onClick={() => { removeUrl(open); setOpen(null) }}>Delete</Button>
+        )}
+      >
+        {open && (
+          <div className="tg-source-info">
+            {info[open]?.image && <img src={info[open].image} alt="" />}
+            <h4>{info[open]?.title || open}</h4>
+            <a href={open} target="_blank" rel="noopener noreferrer">{open}</a>
+          </div>
+        )}
+      </Modal>
     </div>
   )
 }

--- a/client/src/components/__tests__/TGSources.test.jsx
+++ b/client/src/components/__tests__/TGSources.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import TGSources from '../TGSources.jsx'
+import apiFetch from '../../api.js'
+
+vi.mock('../../api.js', () => ({
+  default: vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ title: 'Channel', image: 'img.jpg' }) }))
+}))
+
+describe('TGSources', () => {
+  test('opens modal on title click', async () => {
+    render(<TGSources urls={['https://t.me/test']} addUrl={() => {}} removeUrl={() => {}} />)
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled())
+    fireEvent.click(screen.getByText('Channel'))
+    expect(screen.getByRole('link')).toHaveAttribute('href', 'https://t.me/test')
+  })
+
+  test('delete from modal', async () => {
+    const del = vi.fn()
+    render(<TGSources urls={['https://t.me/test']} addUrl={() => {}} removeUrl={del} />)
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled())
+    fireEvent.click(screen.getByText('Channel'))
+    fireEvent.click(screen.getAllByText('Delete')[1])
+    expect(del).toHaveBeenCalledWith('https://t.me/test')
+  })
+})


### PR DESCRIPTION
## Summary
- enable clicking channel avatar or title to show info
- provide delete action inside modal
- show pointer cursor for clickable elements
- test modal behavior

## Testing
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_687f93e68f6883258f362457554c94d5