### PR TITLE
Fix instance postSuffix access error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -633,6 +633,7 @@ app.get('/api/instances', (req, res) => {
         imageQuality = DEFAULT_IMAGE_QUALITY,
         imageSize = DEFAULT_IMAGE_SIZE,
         referenceImages = [],
+        postSuffix = DEFAULT_POST_SUFFIX,
       }) => ({
         id,
         title,


### PR DESCRIPTION
## Summary
- return `postSuffix` when listing instances

## Testing
- `npm test --prefix server` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fd107c61c8325a0c3e937373babf6