### PR TITLE
Switch suffix input to textarea

### DIFF
--- a/client/src/components/AuthorsTab.jsx
+++ b/client/src/components/AuthorsTab.jsx
@@ -70,10 +70,11 @@ export default function AuthorsTab({ authors, setAuthors, postSuffix, setPostSuf
   return (
     <div className="filters-tab">
       <div className="tg-input">
-        <input
+        <textarea
           value={postSuffix}
           onChange={e => setPostSuffix(e.target.value)}
-          placeholder="Text to append to each post"
+          placeholder="HTML snippet to append to each post"
+          rows={2}
         />
       </div>
       <ul>


### PR DESCRIPTION
## Summary
- use a `<textarea>` for the post suffix field so multi-line HTML snippets can be used

## Testing
- `npx vitest run --dir client` *(fails: `ReferenceError: describe is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_68824fae24208325b9b1c7def9169c5a