### PR TITLE
Add JSDoc comments to modules

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -1,3 +1,9 @@
+/**
+ * Telegram bot helper used by the server to manage channels and send
+ * approval requests.  This module exposes high level functions for
+ * posting messages and media while emitting events for logging and
+ * user interactions.
+ */
 const fs = require('fs');
 const path = require('path');
 const dotenv = require('dotenv');
@@ -23,6 +29,14 @@ const bot = new TelegramBot(token, { polling: true });
 const adminChannels = new Map();
 const channelsByInstance = new Map(); // instanceId -> Set of channel ids
 
+/**
+ * Convert a public @username or t.me link into a numeric Telegram chat ID.
+ * This allows the server to store channels by ID while still accepting
+ * user friendly links.
+ *
+ * @param {string} link Channel invite link or @username
+ * @returns {Promise<[string,{title:string,username:?string}]|null>} Resolved info
+ */
 async function resolveLink(link) {
   const match = link.match(/t\.me\/(.+)/i);
   let identifier = link;
@@ -142,6 +156,10 @@ async function addChannel(instanceId, link) {
   return { id, ...info };
 }
 
+/**
+ * Send a text message to a channel or user.  Errors are logged to the
+ * event emitter so the server can surface them in the UI.
+ */
 async function sendMessage(channel, text, options = {}, instanceId) {
   try {
     await bot.sendMessage(channel, text, { parse_mode: 'HTML', ...options });
@@ -162,6 +180,10 @@ function decodeDataUrl(dataUrl) {
   return Buffer.from(match[2], 'base64');
 }
 
+/**
+ * Send an image to the specified channel.  HTTP and data URLs are
+ * converted to buffers so the Telegram API can accept them.
+ */
 async function sendPhoto(channel, url, caption, options = {}, instanceId) {
   try {
     let payload = url;
@@ -189,6 +211,10 @@ async function sendPhoto(channel, url, caption, options = {}, instanceId) {
   }
 }
 
+/**
+ * Send a video file to a channel.  Unlike images we rely on Telegram to
+ * download the file directly from the provided URL.
+ */
 async function sendVideo(channel, url, caption, options = {}, instanceId) {
   try {
     await bot.sendVideo(channel, url, { caption, parse_mode: 'HTML', ...options });
@@ -203,6 +229,11 @@ async function sendVideo(channel, url, caption, options = {}, instanceId) {
   }
 }
 
+/**
+ * Send a message with inline keyboard asking the given user to approve
+ * a post.  The callback data references the awaiting post ID so the
+ * server can continue processing when the user responds.
+ */
 async function sendApprovalRequest(userId, post) {
   const keyboard = { inline_keyboard: [[
     { text: 'Approve', callback_data: `approve:${post.id}` },
@@ -237,10 +268,18 @@ bot.on('message', (msg) => {
   botEvents.emit('message', msg);
 });
 
+/**
+ * Respond to a callback query so Telegram hides the loading spinner in
+ * the chat.  A short optional message may be shown to the user.
+ */
 function answerCallback(id, text) {
   return bot.answerCallbackQuery(id, { text });
 }
 
+/**
+ * Delete a previously sent message.  Errors are ignored as the message
+ * may have already been removed by the user.
+ */
 function deleteMessage(chatId, messageId) {
   return bot.deleteMessage(chatId, messageId);
 }

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,3 +1,7 @@
+/**
+ * Main application component providing navigation and authentication
+ * handling for the TG News Creator dashboard.
+ */
 import { useState, useEffect } from 'react'
 import apiFetch from './api.js'
 import Instance from './Instance.jsx'

--- a/client/src/Instance.jsx
+++ b/client/src/Instance.jsx
@@ -1,3 +1,7 @@
+/**
+ * Component representing a single posting instance.  Handles scraping
+ * of Telegram channels and posting workflow based on user selections.
+ */
 import { useState, useEffect, useRef } from 'react'
 import Logs from './components/Logs'
 import ChannelSelect from './components/ChannelSelect'
@@ -16,6 +20,11 @@ import apiFetch from './api.js'
 import './App.css'
 
 
+/**
+ * Dashboard component containing the core posting workflow for a single
+ * instance.  It manages state for channels, filters and authors while
+ * streaming Telegram updates via server-sent events.
+ */
 export default function Instance({ id, title, onDelete }) {
   const [news, setNews] = useState([])
   const [es, setEs] = useState(null)
@@ -129,6 +138,11 @@ export default function Instance({ id, title, onDelete }) {
     postSuffixRef.current = postSuffix
   }, [postSuffix])
 
+  /**
+   * Open a server-sent events connection to stream posts or logs.
+   * The token and instance ID are appended to the query string so the
+   * server can authenticate and route events appropriately.
+   */
   const connect = (endpoint, params) => {
     if (es) return
     const qs = new URLSearchParams(params)

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -1,3 +1,6 @@
+/**
+ * Minimal login page used to acquire an access token for the API.
+ */
 import { useState } from 'react'
 import PropTypes from 'prop-types'
 import Button from './components/ui/Button.jsx'

--- a/client/src/Users.jsx
+++ b/client/src/Users.jsx
@@ -1,3 +1,6 @@
+/**
+ * Administration page allowing management of user accounts.
+ */
 import { useState, useEffect } from 'react'
 import Button from './components/ui/Button.jsx'
 import Icon from './components/ui/Icon.jsx'

--- a/client/src/components/AdminTab/AdminTab.jsx
+++ b/client/src/components/AdminTab/AdminTab.jsx
@@ -1,3 +1,7 @@
+/**
+ * Administrative settings tab for an instance.  Allows uploading
+ * reference images and configuring image generation options.
+ */
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from '../ui/Button.jsx'
@@ -10,6 +14,10 @@ const IMAGE_QUALITIES = ['low', 'medium', 'high']
 const IMAGE_SIZES = ['1024x1024', '1024x1536', '1536x1024']
 const DALL_E2_SIZES = ['256x256', '512x512', '1024x1024']
 
+/**
+ * Render the administration tab allowing management of approvers and
+ * reference image settings for a particular instance.
+ */
 export default function AdminTab({ instanceId, onDelete, imageModel, setImageModel, imagePrompt, setImagePrompt, imageQuality, setImageQuality, imageSize, setImageSize }) {
   const [username, setUsername] = useState('')
   const [approvers, setApprovers] = useState([])

--- a/client/src/components/AdminTab/index.js
+++ b/client/src/components/AdminTab/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './AdminTab.jsx';

--- a/client/src/components/AuthorSelect/AuthorSelect.jsx
+++ b/client/src/components/AuthorSelect/AuthorSelect.jsx
@@ -1,5 +1,12 @@
+/**
+ * Dropdown component used to choose an Author GPT profile for rewriting
+ * posts.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Choose an author from the provided list.
+ */
 export default function AuthorSelect({ authors, selected, setSelected }) {
   return (
     <div className="author-select">

--- a/client/src/components/AuthorSelect/index.js
+++ b/client/src/components/AuthorSelect/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './AuthorSelect.jsx';

--- a/client/src/components/AuthorsTab/AuthorsTab.jsx
+++ b/client/src/components/AuthorsTab/AuthorsTab.jsx
@@ -1,9 +1,15 @@
+/**
+ * Tab for managing Author GPT assistants used when rewriting posts.
+ */
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from '../ui/Button.jsx'
 import Modal from '../ui/Modal.jsx'
 import apiFetch from '../../api.js'
 
+/**
+ * Manage the list of author assistants and configure the post suffix.
+ */
 export default function AuthorsTab({ authors, setAuthors, postSuffix, setPostSuffix }) {
   const [showForm, setShowForm] = useState(false)
   const [title, setTitle] = useState('')

--- a/client/src/components/AuthorsTab/index.js
+++ b/client/src/components/AuthorsTab/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './AuthorsTab.jsx';

--- a/client/src/components/ChannelSelect/ChannelSelect.jsx
+++ b/client/src/components/ChannelSelect/ChannelSelect.jsx
@@ -1,5 +1,11 @@
+/**
+ * List of Telegram channels with checkboxes for selecting posting targets.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Render a multi-select checkbox list of channels.
+ */
 export default function ChannelSelect({ channels, selected, setSelected }) {
   const toggle = (id) => {
     setSelected(prev => prev.includes(id) ? prev.filter(c => c !== id) : [...prev, id])

--- a/client/src/components/ChannelSelect/index.js
+++ b/client/src/components/ChannelSelect/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './ChannelSelect.jsx';

--- a/client/src/components/Controls/Controls.jsx
+++ b/client/src/components/Controls/Controls.jsx
@@ -1,6 +1,12 @@
+/**
+ * Simple set of buttons used to start/stop scraping and posting.
+ */
 import PropTypes from 'prop-types'
 import Button from '../ui/Button.jsx'
 
+/**
+ * Display buttons for controlling background tasks.
+ */
 export default function Controls({ startGet, startPost, stop, startLabel = 'Start Getting', disabled = false }) {
   return (
     <div className="controls">

--- a/client/src/components/Controls/index.js
+++ b/client/src/components/Controls/index.js
@@ -1,1 +1,2 @@
+// Re-export convenience entry for bundlers
 export { default } from './Controls.jsx';

--- a/client/src/components/FilterSelect/FilterSelect.jsx
+++ b/client/src/components/FilterSelect/FilterSelect.jsx
@@ -1,5 +1,11 @@
+/**
+ * Dropdown component for selecting a post filter.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Choose which filter to apply to scraped posts.
+ */
 export default function FilterSelect({ filters, selected, setSelected }) {
   return (
     <div className="filter-select">

--- a/client/src/components/FilterSelect/index.js
+++ b/client/src/components/FilterSelect/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './FilterSelect.jsx';

--- a/client/src/components/FiltersTab/FiltersTab.jsx
+++ b/client/src/components/FiltersTab/FiltersTab.jsx
@@ -1,9 +1,15 @@
+/**
+ * Tab displaying and creating content filters powered by OpenAI.
+ */
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from '../ui/Button.jsx'
 import Modal from '../ui/Modal.jsx'
 import apiFetch from '../../api.js'
 
+/**
+ * Manage the list of available filters.
+ */
 export default function FiltersTab({ filters, setFilters }) {
   const [showForm, setShowForm] = useState(false)
   const [title, setTitle] = useState('')

--- a/client/src/components/FiltersTab/index.js
+++ b/client/src/components/FiltersTab/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './FiltersTab.jsx';

--- a/client/src/components/Logs/Logs.jsx
+++ b/client/src/components/Logs/Logs.jsx
@@ -1,5 +1,11 @@
+/**
+ * Simple scrolling log output used during scraping and posting.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Render an array of log messages.
+ */
 export default function Logs({ logs }) {
   return (
     <div className="logs" role="log">

--- a/client/src/components/Logs/index.js
+++ b/client/src/components/Logs/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './Logs.jsx';

--- a/client/src/components/ModeToggle/ModeToggle.jsx
+++ b/client/src/components/ModeToggle/ModeToggle.jsx
@@ -1,5 +1,11 @@
+/**
+ * Toggle component switching between raw JSON and rendered post view.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Choose how scraped posts should be displayed.
+ */
 export default function ModeToggle({ mode, setMode }) {
   return (
     <div className="mode-toggle">

--- a/client/src/components/ModeToggle/index.js
+++ b/client/src/components/ModeToggle/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './ModeToggle.jsx';

--- a/client/src/components/NewsItem/NewsItem.jsx
+++ b/client/src/components/NewsItem/NewsItem.jsx
@@ -1,6 +1,12 @@
+/**
+ * Individual scraped news item.  Can render raw JSON or HTML.
+ */
 import PropTypes from 'prop-types'
 import DOMPurify from 'dompurify'
 
+/**
+ * Render a single news item using the selected display mode.
+ */
 export default function NewsItem({ item, mode }) {
   return (
     <div className="news-item">

--- a/client/src/components/NewsItem/index.js
+++ b/client/src/components/NewsItem/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './NewsItem.jsx';

--- a/client/src/components/NewsList/NewsList.jsx
+++ b/client/src/components/NewsList/NewsList.jsx
@@ -1,6 +1,12 @@
+/**
+ * List container for displaying multiple scraped posts.
+ */
 import PropTypes from 'prop-types'
 import NewsItem from '../NewsItem'
 
+/**
+ * Render a list of news items.
+ */
 export default function NewsList({ news, mode }) {
   return (
     <div className="news-list">

--- a/client/src/components/NewsList/index.js
+++ b/client/src/components/NewsList/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './NewsList.jsx';

--- a/client/src/components/SourcesTable/SourcesTable.jsx
+++ b/client/src/components/SourcesTable/SourcesTable.jsx
@@ -1,5 +1,11 @@
+/**
+ * Table listing news sources and their scraping status.
+ */
 import PropTypes from 'prop-types'
 
+/**
+ * Render a table of available sources with selection checkboxes.
+ */
 export default function SourcesTable({ sources, selected, toggle, statuses = {} }) {
   return (
     <table className="sources">

--- a/client/src/components/SourcesTable/index.js
+++ b/client/src/components/SourcesTable/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './SourcesTable.jsx';

--- a/client/src/components/TGSources/TGSources.jsx
+++ b/client/src/components/TGSources/TGSources.jsx
@@ -1,9 +1,15 @@
+/**
+ * Form allowing entry of Telegram channel URLs to scrape.
+ */
 import { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from '../ui/Button.jsx'
 import Modal from '../ui/Modal.jsx'
 import apiFetch from '../../api.js'
 
+/**
+ * Manage the list of Telegram source URLs.
+ */
 export default function TGSources({ urls, addUrl, removeUrl }) {
   const [value, setValue] = useState('')
   const [info, setInfo] = useState({})

--- a/client/src/components/TGSources/index.js
+++ b/client/src/components/TGSources/index.js
@@ -1,1 +1,2 @@
+// Re-export component for cleaner imports
 export { default } from './TGSources.jsx';

--- a/client/src/components/ui/Button.jsx
+++ b/client/src/components/ui/Button.jsx
@@ -1,3 +1,7 @@
+/**
+ * Reusable button component that automatically picks an icon based on
+ * the label text.
+ */
 import PropTypes from 'prop-types'
 import './button.css'
 import { Children } from 'react'

--- a/client/src/components/ui/Icon.jsx
+++ b/client/src/components/ui/Icon.jsx
@@ -1,3 +1,6 @@
+/**
+ * Lightweight inline SVG icon component used across the dashboard.
+ */
 import PropTypes from 'prop-types'
 /**
  * Render an inline SVG icon.  The `iconDef` prop should be an object

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -1,7 +1,13 @@
+/**
+ * Generic modal dialog used for confirmations and forms.
+ */
 import PropTypes from 'prop-types'
 import Button from './Button.jsx'
 import './modal.css'
 
+/**
+ * Render a modal dialog when `open` is true.
+ */
 export default function Modal({ open, onClose, children, actions = null }) {
   if (!open) return null
   return (

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,3 +1,7 @@
+/**
+ * Entry point for the React application.  Renders the App component into
+ * the DOM using React 18's `createRoot` API.
+ */
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'


### PR DESCRIPTION
## Summary
- add file-level descriptions and JSDoc comments across server and client
- explain major logic in comments

## Testing
- `npm install --prefix client`
- `npm test --prefix client` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688791b0eb548325a738e1c07def2d5e