### PR TITLE
Add domain env support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN npm run build --prefix client
 FROM node:20
 WORKDIR /app
 COPY --from=builder /app ./
+ENV DOMAIN=http://localhost:3001
 EXPOSE 3001
 CMD ["npm", "start", "--prefix", "server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     env_file:
       - server/.env
     environment:
+      - DOMAIN=${DOMAIN:-http://localhost:3001}
       - HTTP_PROXY
       - HTTPS_PROXY
       - http_proxy

--- a/server/index.js
+++ b/server/index.js
@@ -527,6 +527,7 @@ app.use((req, res, next) => {
   }
 });
 const PORT = process.env.PORT || 3001;
+const DOMAIN = process.env.DOMAIN || `http://localhost:${PORT}`;
 
 const CLIENT_DIST = path.join(__dirname, '..', 'client', 'dist');
 if (fs.existsSync(CLIENT_DIST)) {
@@ -538,7 +539,7 @@ const swaggerSpec = swaggerJsdoc({
   definition: {
     openapi: '3.0.0',
     info: { title: 'News API', version: '1.0.0' },
-    servers: [{ url: `http://localhost:${PORT}` }]
+    servers: [{ url: DOMAIN }]
   },
   apis: [__filename]
 });


### PR DESCRIPTION
## Summary
- enable domain configuration for API docs
- default to localhost domain in Docker runtime
- pass DOMAIN variable via docker compose

## Testing
- `npm install --prefix client`
- `npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_6888dc1442148325a04cae586d91aa0b