### PR TITLE
Add workflow to split single-commit PRs using GPT

### DIFF
--- a/.github/workflows/split-pr.yml
+++ b/.github/workflows/split-pr.yml
@@ -1,0 +1,31 @@
+name: Split PR Commit
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+jobs:
+  split_commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Count commits
+        id: commits
+        run: echo "count=$(git rev-list --count origin/${{ github.base_ref }}..HEAD)" >> $GITHUB_OUTPUT
+      - name: Write OpenAI key
+        if: steps.commits.outputs.count == '1'
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: echo "$OPENAI_API_KEY" > openai.key
+      - name: Split commit using GPT
+        if: steps.commits.outputs.count == '1'
+        env:
+          OPENAI_API_KEY_FILE: openai.key
+          PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+        run: node scripts/split-commit.js
+      - name: Push rewritten commits
+        if: steps.commits.outputs.count == '1'
+        run: git push --force-with-lease

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ server/node_modules
 .env
 data.db
 server/uploads/
+openai.key

--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -1,0 +1,44 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+(async () => {
+  const apiKeyPath = process.env.OPENAI_API_KEY_FILE || 'openai.key';
+  const apiKey = fs.readFileSync(apiKeyPath, 'utf8').trim();
+  const diff = execSync('git diff origin/main...HEAD', { encoding: 'utf8' });
+  const prDescription = process.env.PR_DESCRIPTION || '';
+
+  const prompt = `PR Description:\n${prDescription}\n\nDiff:\n${diff}\n\nSplit the diff into multiple small commits. Return JSON array where each item has {"message": string, "patch": string}. Patches must apply sequentially starting from the base branch.`;
+
+  const response = await fetch('https://api.openai.com/v1/responses', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini',
+      input: prompt
+    })
+  });
+  const data = await response.json();
+  const content = data.output?.[0]?.content?.[0]?.text || '';
+
+  let commits;
+  try {
+    commits = JSON.parse(content);
+  } catch (err) {
+    console.error('Failed to parse GPT response:', content);
+    process.exit(1);
+  }
+
+  execSync('git reset --hard origin/main');
+
+  commits.forEach((commit, index) => {
+    const patchFile = `patch_${index}.diff`;
+    fs.writeFileSync(patchFile, commit.patch);
+    execSync(`git apply ${patchFile}`);
+    execSync('git add -A');
+    execSync(`git commit -m ${JSON.stringify(commit.message)}`);
+    fs.unlinkSync(patchFile);
+  });
+})();


### PR DESCRIPTION
## Summary
- introduce GitHub workflow that splits single-commit PRs by calling GPT-4o
- add script that rewrites commit history based on OpenAI's suggested patches
- ignore `openai.key` to avoid committing secrets

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688e0977bbdc8325aec5e98310e72d00