### PR TITLE
Fetch base branch before counting commits

### DIFF
--- a/.github/workflows/split-pr.yml
+++ b/.github/workflows/split-pr.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.base_ref }}
       - name: Count commits
         id: commits
         run: echo "count=$(git rev-list --count origin/${{ github.base_ref }}..HEAD)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- ensure base branch is fetched so commit counts work in split-pr workflow

## Testing
- `npm test --prefix client`
- `npm test --prefix server` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_688e177371888325a5e5c063cbdd8dc4