### PR TITLE
Add tests for ui components in the client

### DIFF
--- a/client/src/components/__tests__/Button.test.jsx
+++ b/client/src/components/__tests__/Button.test.jsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import Button from '../ui/Button'
+
+describe('Button', () => {
+  test('adds icon and danger variant for delete label', () => {
+    const { container } = render(<Button>Delete item</Button>)
+    const button = container.querySelector('button')
+    expect(button.className).toContain('shadcn-btn-danger')
+    expect(container.querySelector('.btn-icon')).toBeInTheDocument()
+  })
+
+  test('uses provided startIcon without changing variant', () => {
+    const icon = '<svg data-testid="custom"></svg>'
+    const { container } = render(<Button startIcon={icon}>Delete</Button>)
+    const button = container.querySelector('button')
+    expect(button.className).toContain('shadcn-btn-primary')
+    expect(container.querySelector('[data-testid="custom"]')).toBeInTheDocument()
+  })
+})

--- a/client/src/components/__tests__/Icon.test.jsx
+++ b/client/src/components/__tests__/Icon.test.jsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react'
+import Icon from '../ui/Icon'
+
+describe('Icon', () => {
+  const def = { width: 16, height: 16, svgPathData: 'M0 0h16v16H0z' }
+
+  test('renders svg markup', () => {
+    const { container } = render(<Icon iconDef={def} />)
+    const span = container.querySelector('span.fa-icon')
+    expect(span).toBeInTheDocument()
+    expect(span.innerHTML).toContain(def.svgPathData)
+  })
+
+  test('applies custom class', () => {
+    const { container } = render(<Icon iconDef={def} className="extra" />)
+    const span = container.querySelector('span.fa-icon')
+    expect(span.className).toContain('extra')
+  })
+})

--- a/client/src/components/__tests__/Modal.test.jsx
+++ b/client/src/components/__tests__/Modal.test.jsx
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Modal from '../ui/Modal'
+
+describe('Modal', () => {
+  test('does not render when closed', () => {
+    const { container } = render(<Modal open={false} onClose={() => {}}>content</Modal>)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('renders content and close button when open', () => {
+    render(<Modal open onClose={() => {}}>content</Modal>)
+    expect(screen.getByText('content')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  test('backdrop and close button trigger onClose, modal body does not', () => {
+    const fn = vi.fn()
+    const { container } = render(
+      <Modal open onClose={fn}>
+        <div>body</div>
+      </Modal>
+    )
+    fireEvent.click(container.firstChild) // backdrop
+    expect(fn).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+    expect(fn).toHaveBeenCalledTimes(2)
+    fireEvent.click(container.querySelector('.modal'))
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add coverage for Button component including automatic icon selection
- validate Icon rendering and custom classes
- ensure Modal renders and closes correctly

## Testing
- `cd client && npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_688e190785988325b5d9377c1cf01a95