### PR TITLE
feat: log commit count in split PR workflow

### DIFF
--- a/.github/workflows/split-pr.yml
+++ b/.github/workflows/split-pr.yml
@@ -12,11 +12,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Fetch base branch
         run: git fetch origin ${{ github.base_ref }}
       - name: Count commits
         id: commits
-        run: echo "count=$(git rev-list --count origin/${{ github.base_ref }}..HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          count=$(git rev-list --count origin/${{ github.base_ref }}..HEAD)
+          echo "Commit count: $count"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
       - name: Write OpenAI key
         if: steps.commits.outputs.count == '1'
         env:


### PR DESCRIPTION
## Summary
- log commit count and save to GITHUB_OUTPUT
- checkout pull request head commit to avoid merge commit counts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e1b219b888325952c2efb32a0aeb7