### PR TITLE
Ensure JSON output from split commit workflow

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -17,11 +17,30 @@ const fs = require('fs');
     },
     body: JSON.stringify({
       model: 'gpt-4o-mini',
-      input: prompt
+      input: prompt,
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'commit_splits',
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                message: { type: 'string' },
+                patch: { type: 'string' }
+              },
+              required: ['message', 'patch'],
+              additionalProperties: false
+            }
+          },
+          strict: true
+        }
+      }
     })
   });
   const data = await response.json();
-  const content = data.output?.[0]?.content?.[0]?.text || '';
+  const content = data.output_text || '';
 
   let commits;
   try {


### PR DESCRIPTION
## Summary
- enforce JSON schema on OpenAI commit-splitting responses
- parse aggregated response text to avoid malformed output

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_688e291a85688325a534edcfdc27e1ba