### PR TITLE
test: add ui component tests

### DIFF
--- a/client/src/components/ui/__tests__/Button.test.jsx
+++ b/client/src/components/ui/__tests__/Button.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import Button from '../Button'
+
+describe('Button', () => {
+  test('renders children', () => {
+    render(<Button>Click me</Button>)
+    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument()
+  })
+
+  test('auto adds icon and danger variant for delete label', () => {
+    render(<Button>Delete item</Button>)
+    const button = screen.getByRole('button', { name: /delete item/i })
+    expect(button).toHaveClass('shadcn-btn-danger')
+    expect(button.querySelector('.btn-icon')).toBeInTheDocument()
+  })
+
+  test('uses provided startIcon and keeps primary variant', () => {
+    const icon = '<svg data-testid="custom-icon"></svg>'
+    render(<Button startIcon={icon}>Delete</Button>)
+    const button = screen.getByRole('button', { name: /delete/i })
+    expect(button).toHaveClass('shadcn-btn-primary')
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument()
+  })
+})

--- a/client/src/components/ui/__tests__/Icon.test.jsx
+++ b/client/src/components/ui/__tests__/Icon.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react'
+import Icon from '../Icon'
+
+describe('Icon', () => {
+  test('renders svg from iconDef', () => {
+    const iconDef = { width: 10, height: 10, svgPathData: 'M0 0h10v10H0z' }
+    const { container } = render(<Icon iconDef={iconDef} className="extra" />)
+    const span = container.querySelector('span.fa-icon.extra')
+    expect(span).toBeInTheDocument()
+    expect(span.innerHTML).toContain('svg')
+    expect(span.innerHTML).toContain('M0 0h10v10H0z')
+  })
+})

--- a/client/src/components/ui/__tests__/Modal.test.jsx
+++ b/client/src/components/ui/__tests__/Modal.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Modal from '../Modal'
+
+describe('Modal', () => {
+  test('does not render when closed', () => {
+    const { container } = render(<Modal open={false} onClose={() => {}}>Body</Modal>)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('renders children and actions when open', () => {
+    render(
+      <Modal open onClose={() => {}} actions={<button>Action</button>}>
+        Content
+      </Modal>
+    )
+    expect(screen.getByText('Content')).toBeInTheDocument()
+    expect(screen.getByText('Action')).toBeInTheDocument()
+    expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+
+  test('calls onClose when close button clicked', () => {
+    const fn = vi.fn()
+    render(<Modal open onClose={fn}>Body</Modal>)
+    fireEvent.click(screen.getByText('Close'))
+    expect(fn).toHaveBeenCalled()
+  })
+
+  test('calls onClose when backdrop clicked', () => {
+    const fn = vi.fn()
+    const { container } = render(<Modal open onClose={fn}>Body</Modal>)
+    fireEvent.click(container.querySelector('.modal-backdrop'))
+    expect(fn).toHaveBeenCalled()
+  })
+
+  test('does not call onClose when modal content clicked', () => {
+    const fn = vi.fn()
+    const { container } = render(<Modal open onClose={fn}>Body</Modal>)
+    fireEvent.click(container.querySelector('.modal'))
+    expect(fn).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for Button ensuring children, auto icon, and custom icons
- add tests for Icon verifying SVG rendering
- add tests for Modal covering rendering and close behavior

## Testing
- `CI=1 npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_688e2a4fe4a88325ba06f10b33ef712d