### PR TITLE
test: add tests for UI components

### DIFF
--- a/client/src/components/ui/__tests__/Button.test.jsx
+++ b/client/src/components/ui/__tests__/Button.test.jsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import Button from '../Button.jsx'
+
+describe('Button', () => {
+  test('renders children with default primary style', () => {
+    render(<Button>Click me</Button>)
+    const btn = screen.getByRole('button', { name: /click me/i })
+    expect(btn).toHaveClass('shadcn-btn-primary')
+  })
+
+  test('detects delete keyword and shows danger style with icon', () => {
+    render(<Button>Delete item</Button>)
+    const btn = screen.getByRole('button', { name: /delete item/i })
+    expect(btn).toHaveClass('shadcn-btn-danger')
+    expect(btn.querySelector('.btn-icon')).toBeInTheDocument()
+  })
+
+  test('renders provided startIcon HTML', () => {
+    render(<Button startIcon='<svg data-testid="start-icon"></svg>'>Save</Button>)
+    expect(screen.getByTestId('start-icon')).toBeInTheDocument()
+    const btn = screen.getByRole('button', { name: /save/i })
+    expect(btn).toHaveClass('shadcn-btn-primary')
+  })
+})

--- a/client/src/components/ui/__tests__/Icon.test.jsx
+++ b/client/src/components/ui/__tests__/Icon.test.jsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react'
+import Icon from '../Icon.jsx'
+
+describe('Icon', () => {
+  const testIcon = { width: 10, height: 20, svgPathData: 'M0 0h10v20z' }
+
+  test('renders span with svg markup', () => {
+    const { container } = render(<Icon iconDef={testIcon} className="extra" />)
+    const span = container.querySelector('span')
+    expect(span).toHaveClass('fa-icon', 'extra')
+    expect(span.innerHTML).toContain(testIcon.svgPathData)
+  })
+})

--- a/client/src/components/ui/__tests__/Modal.test.jsx
+++ b/client/src/components/ui/__tests__/Modal.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Modal from '../Modal.jsx'
+
+describe('Modal', () => {
+  test('renders content and default close button when open', () => {
+    render(<Modal open onClose={() => {}}>Hello</Modal>)
+    expect(screen.getByText('Hello')).toBeInTheDocument()
+    expect(screen.getByText('Close')).toBeInTheDocument()
+  })
+
+  test('does not render when closed', () => {
+    const { queryByText } = render(<Modal open={false} onClose={() => {}}>Hi</Modal>)
+    expect(queryByText('Hi')).toBeNull()
+  })
+
+  test('invokes onClose when clicking close button', () => {
+    const fn = vi.fn()
+    render(<Modal open onClose={fn}>Hi</Modal>)
+    fireEvent.click(screen.getByText('Close'))
+    expect(fn).toHaveBeenCalled()
+  })
+
+  test('renders custom actions and backdrop click closes', () => {
+    const fn = vi.fn()
+    const { container } = render(
+      <Modal open onClose={fn} actions={<button>Action</button>}>
+        Content
+      </Modal>
+    )
+    expect(screen.getByText('Action')).toBeInTheDocument()
+    fireEvent.click(container.firstChild) // click backdrop
+    expect(fn).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add unit tests for Button component, covering style and icon logic
- add unit tests for Icon component rendering
- add unit tests for Modal component behaviors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e2bc912c88325a7f249ca354b499c