### PR TITLE
feat: log full OpenAI API response

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -39,7 +39,17 @@ const fs = require('fs');
       }
     })
   });
-  const data = await response.json();
+  const responseText = await response.text();
+  console.log('Full OpenAI API response:', responseText);
+
+  let data;
+  try {
+    data = JSON.parse(responseText);
+  } catch (err) {
+    console.error('Failed to parse OpenAI API response as JSON:', responseText);
+    process.exit(1);
+  }
+
   const content = data.output_text || '';
   console.log('GPT response:', content);
 


### PR DESCRIPTION
## Summary
- Print the full OpenAI API response before parsing in `split-commit.js` to aid debugging when parsing fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm test --prefix server` *(fails: Error: no test specified)*
- `CI=1 npm test --prefix client`

------
https://chatgpt.com/codex/tasks/task_e_688e6619b7d483259a668e2b663077ce