### PR TITLE
fix: update OpenAI responses format usage

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -18,23 +18,25 @@ const fs = require('fs');
     body: JSON.stringify({
       model: 'gpt-4o-mini',
       input: prompt,
-      response_format: {
-        type: 'json_schema',
-        json_schema: {
-          name: 'commit_splits',
-          schema: {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                message: { type: 'string' },
-                patch: { type: 'string' }
-              },
-              required: ['message', 'patch'],
-              additionalProperties: false
-            }
-          },
-          strict: true
+      text: {
+        format: {
+          type: 'json_schema',
+          json_schema: {
+            name: 'commit_splits',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  message: { type: 'string' },
+                  patch: { type: 'string' }
+                },
+                required: ['message', 'patch'],
+                additionalProperties: false
+              }
+            },
+            strict: true
+          }
         }
       }
     })

--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -21,22 +21,20 @@ const fs = require('fs');
       text: {
         format: {
           type: 'json_schema',
-          json_schema: {
-            name: 'commit_splits',
-            schema: {
-              type: 'array',
-              items: {
-                type: 'object',
-                properties: {
-                  message: { type: 'string' },
-                  patch: { type: 'string' }
-                },
-                required: ['message', 'patch'],
-                additionalProperties: false
-              }
-            },
-            strict: true
-          }
+          name: 'commit_splits',
+          schema: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                message: { type: 'string' },
+                patch: { type: 'string' }
+              },
+              required: ['message', 'patch'],
+              additionalProperties: false
+            }
+          },
+          strict: true
         }
       }
     })


### PR DESCRIPTION
## Summary
- update OpenAI split commit script to use `text.format` instead of deprecated `response_format`

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client`
- `npm run lint --prefix client` *(fails: Definition for rule 'react/no-danger' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e68afc0888325be0b3db134a723d0