### PR TITLE
Improve diff application for AI-generated commits

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -31,7 +31,7 @@ const fs = require('fs');
                   type: 'object',
                   properties: {
                     message: { type: 'string' },
-                    patch: { type: 'string' }
+                    patch: { type: 'string', format: 'diff' }
                   },
                   required: ['message', 'patch'],
                   additionalProperties: false
@@ -89,7 +89,14 @@ const fs = require('fs');
 
   commits.forEach((commit, index) => {
     const patchFile = `patch_${index}.diff`;
-    fs.writeFileSync(patchFile, commit.patch);
+    const patchContent = commit.patch.endsWith('\n') ? commit.patch : `${commit.patch}\n`;
+    fs.writeFileSync(patchFile, patchContent);
+    try {
+      execSync(`git apply --check ${patchFile}`);
+    } catch (err) {
+      console.error(`Patch validation failed for ${patchFile}:`, patchContent);
+      throw err;
+    }
     execSync(`git apply ${patchFile}`);
     execSync('git add -A');
     execSync(`git commit -m ${JSON.stringify(commit.message)}`);

--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -31,7 +31,7 @@ const fs = require('fs');
                   type: 'object',
                   properties: {
                     message: { type: 'string' },
-                    patch: { type: 'string', format: 'diff' }
+                    patch: { type: 'string', pattern: '^diff --git ' }
                   },
                   required: ['message', 'patch'],
                   additionalProperties: false


### PR DESCRIPTION
## Summary
- enforce diff formatting in OpenAI structured output
- validate and normalize patches before applying

## Testing
- `npm test` (fails: Missing script: "test")
- `node scripts/split-commit.js` (fails: ambiguous argument 'origin/main...HEAD')

------
https://chatgpt.com/codex/tasks/task_e_688e7368c7ac8325ad814e2dad88e3cd