### PR TITLE
Replace axios with fetch in commit splitting script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,9 +6,7 @@
     "": {
       "name": "tg-news-creator-root",
       "dependencies": {
-        "axios": "^1.9.0",
         "dotenv": "^16.4.5",
-        "form-data": "^4.0.0",
         "node-telegram-bot-api": "^0.61.0"
       },
       "devDependencies": {
@@ -184,17 +182,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
       "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -767,6 +754,7 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -805,22 +793,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/function-bind": {
@@ -1767,12 +1739,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
     "node_modules/psl": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   },
   "dependencies": {
     "dotenv": "^16.4.5",
-    "node-telegram-bot-api": "^0.61.0",
-    "axios": "^1.9.0",
-    "form-data": "^4.0.0"
+    "node-telegram-bot-api": "^0.61.0"
   },
   "devDependencies": {
     "concurrently": "^8.2.0",

--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -1,7 +1,7 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
-const axios = require('axios');
-const FormData = require('form-data');
+// Use built-in fetch and FormData available in Node.js >=18
+// to avoid external dependencies like axios or form-data.
 
 function logBlock(title, content, logger = console.log) {
   logger('---');
@@ -22,18 +22,23 @@ function logBlock(title, content, logger = console.log) {
 
   const uploadForm = new FormData();
   uploadForm.append('purpose', 'assistants');
-  uploadForm.append('file', fs.createReadStream(diffFile));
+  const fileBuffer = fs.readFileSync(diffFile);
+  uploadForm.append('file', new Blob([fileBuffer], { type: 'text/plain' }), diffFile);
   let uploadJson;
   try {
-    const uploadRes = await axios.post('https://api.openai.com/v1/files', uploadForm, {
+    const uploadRes = await fetch('https://api.openai.com/v1/files', {
+      method: 'POST',
       headers: {
-        ...uploadForm.getHeaders(),
         Authorization: `Bearer ${apiKey}`
-      }
+      },
+      body: uploadForm
     });
-    uploadJson = uploadRes.data;
+    uploadJson = await uploadRes.json();
+    if (!uploadRes.ok) {
+      throw new Error(uploadJson.error?.message || uploadRes.statusText);
+    }
   } catch (err) {
-    console.error('Failed to upload diff file:', err.response?.data || err.message);
+    console.error('Failed to upload diff file:', err.message);
     process.exit(1);
   }
   if (!uploadJson.id) {


### PR DESCRIPTION
## Summary
- use built-in fetch and FormData in split-commit script
- remove unnecessary axios and form-data dependencies

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_688e8e3ccff48325a71058663d935abf