### PR TITLE
fix split commit attachments

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -57,12 +57,12 @@ function logBlock(title, content, logger = console.log) {
     },
     body: JSON.stringify({
       model: 'gpt-4o',
+      attachments: [{ file_id: fileId }],
       input: [{
         role: 'user',
         content: [
           { type: 'input_text', text: prompt }
-        ],
-        attachments: [{ file_id: fileId }]
+        ]
       }],
       text: {
         format: {


### PR DESCRIPTION
## Summary
- correct OpenAI API request by moving file attachment outside the input message

## Testing
- `npm test`
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e957b12d88325abdc2e79d0739234