### PR TITLE
fix split commit attachments

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -60,9 +60,9 @@ function logBlock(title, content, logger = console.log) {
       input: [{
         role: 'user',
         content: [
-          { type: 'input_text', text: prompt }
-        ],
-        attachments: [{ file_id: fileId }]
+          { type: 'input_text', text: prompt },
+          { type: 'input_file', file_id: fileId }
+        ]
       }],
       text: {
         format: {


### PR DESCRIPTION
## Summary
- send diff file using an `input_file` message part in split-commit script instead of unsupported top-level attachments

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix server` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688e957b12d88325abdc2e79d0739234