### PR TITLE
feat: save script logs

### DIFF
--- a/.github/workflows/split-pr.yml
+++ b/.github/workflows/split-pr.yml
@@ -50,3 +50,9 @@ jobs:
       - name: Push rewritten commits
         if: steps.commits.outputs.count == '1'
         run: git push --force-with-lease origin HEAD:${{ github.event.pull_request.head.ref }}
+      - name: Upload script logs
+        if: steps.commits.outputs.count == '1' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: script-logs
+          path: logs

--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -1,13 +1,25 @@
 const { execSync } = require('child_process');
 const fs = require('fs');
+const path = require('path');
 const PDFDocument = require('pdfkit');
 // Use built-in fetch and FormData available in Node.js >=18
 // to avoid external dependencies like axios or form-data.
 
 function logBlock(title, content, logger = console.log) {
-  logger('---');
-  logger(title);
-  if (content !== undefined) logger(content);
+  const separator = '_________________________';
+  const lines = [separator, title];
+  if (content !== undefined) lines.push(content);
+  lines.push(separator);
+  const message = lines.join('\n');
+
+  logger(message);
+
+  const dir = 'logs';
+  fs.mkdirSync(dir, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/:/g, '-');
+  const action = title.toLowerCase().replace(/[^a-z0-9]+/gi, '-').replace(/^-|-$/g, '');
+  const fileName = `${timestamp}-${action}.txt`;
+  fs.writeFileSync(path.join(dir, fileName), `${message}\n`);
 }
 
 function textToPdf(text, filePath) {


### PR DESCRIPTION
## Summary
- wrap log output with separators and save each block to a dated file
- upload generated log files as workflow artifacts

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ea5ebebd08325b63a5367ba91776e