### PR TITLE
feat: assemble commit hunks

### DIFF
--- a/scripts/split-commit.js
+++ b/scripts/split-commit.js
@@ -5,6 +5,59 @@ const PDFDocument = require('pdfkit');
 // Use built-in fetch and FormData available in Node.js >=18
 // to avoid external dependencies like axios or form-data.
 
+// Parse a unified diff into file headers and individual hunks
+function parseDiff(diff) {
+  const files = {};
+  const lines = diff.split('\n');
+  let i = 0;
+  while (i < lines.length) {
+    if (!lines[i].startsWith('diff --git')) { i++; continue; }
+    const headerLines = [lines[i]];
+    i++;
+    while (i < lines.length && !lines[i].startsWith('@@') && !lines[i].startsWith('diff --git')) {
+      headerLines.push(lines[i]);
+      i++;
+    }
+    const filePathLine = headerLines.find(l => l.startsWith('+++ b/')) || '';
+    const filePath = filePathLine.replace('+++ b/', '');
+    const hunks = [];
+    while (i < lines.length && !lines[i].startsWith('diff --git')) {
+      if (lines[i].startsWith('@@')) {
+        const hunkLines = [lines[i]];
+        i++;
+        while (i < lines.length && !lines[i].startsWith('@@') && !lines[i].startsWith('diff --git')) {
+          hunkLines.push(lines[i]);
+          i++;
+        }
+        hunks.push(hunkLines.join('\n') + '\n');
+      } else {
+        i++;
+      }
+    }
+    files[filePath] = {
+      header: headerLines.join('\n') + '\n',
+      hunks
+    };
+  }
+  return files;
+}
+
+// Build a diff text with hunk numbers appended for the model
+function buildAnnotatedDiff(files) {
+  let out = '';
+  for (const { header, hunks } of Object.values(files)) {
+    out += header;
+    hunks.forEach((hunk, idx) => {
+      const lines = hunk.split('\n');
+      if (lines[0].startsWith('@@')) {
+        lines[0] = `${lines[0]}  # hunk ${idx + 1}`;
+      }
+      out += lines.join('\n') + '\n';
+    });
+  }
+  return out;
+}
+
 function logBlock(title, content, logger = console.log) {
   const separator = '_________________________';
   const lines = [separator, title];
@@ -39,12 +92,15 @@ function textToPdf(text, filePath) {
   const apiKeyPath = process.env.OPENAI_API_KEY_FILE || 'openai.key';
   const apiKey = fs.readFileSync(apiKeyPath, 'utf8').trim();
   const baseBranch = process.env.BASE_BRANCH || 'main';
-  const diff = execSync(`git diff origin/${baseBranch}...HEAD`, { encoding: 'utf8' });
+  const origDiff = execSync(`git diff origin/${baseBranch}...HEAD`, { encoding: 'utf8' });
   const prDescription = process.env.PR_DESCRIPTION || '';
 
-  logBlock('Original diff from base branch to HEAD:', diff);
+  const parsedDiff = parseDiff(origDiff);
+  const annotatedDiff = buildAnnotatedDiff(parsedDiff);
+  logBlock('Original diff from base branch to HEAD:', origDiff);
+  logBlock('Annotated diff with hunk numbers:', annotatedDiff);
   const diffFile = 'diff.pdf';
-  await textToPdf(diff, diffFile);
+  await textToPdf(annotatedDiff, diffFile);
 
   const uploadForm = new FormData();
   uploadForm.append('purpose', 'assistants');
@@ -73,7 +129,8 @@ function textToPdf(text, filePath) {
   }
   const fileId = uploadJson.id;
 
-  const prompt = `PR Description:\n${prDescription}\n\nThe full diff is provided in the attached file. Split the diff into multiple small commits. Return JSON object {"commits": [{"message": string, "patch": string}]}.\nEach patch must be a valid unified diff starting with "diff --git" and ending with a newline.\nPatches must apply sequentially starting from the base branch and, when combined in order, must exactly reproduce the diff in the attached file. Double-check that your patches together match the file.`;
+  const systemPrompt = 'You are an experienced git reviewer.';
+  const userPrompt = `PR description: ${prDescription}\n\nAttached: full diff\n\nReturn JSON:\n{\n  "commits": [\n    {\n      "message": "...",\n      "files": [\n         { "path": "src/foo.ts", "hunks": [3,4] },\n         { "path": "docs/readme.md", "hunks": [1] }\n      ]\n    }\n  ]\n}\n\nRules:\n- DO NOT rewrite any lines of the diff.\n- Only reference existing hunks by their ordinal number in the attached diff (each hunk is annotated with \"# hunk N\").`;
 
   const response = await fetch('https://api.openai.com/v1/responses', {
     method: 'POST',
@@ -83,13 +140,21 @@ function textToPdf(text, filePath) {
     },
     body: JSON.stringify({
       model: 'gpt-4o',
-      input: [{
-        role: 'user',
-        content: [
-          { type: 'input_text', text: prompt },
-          { type: 'input_file', file_id: fileId }
-        ]
-      }],
+      input: [
+        {
+          role: 'system',
+          content: [
+            { type: 'input_text', text: systemPrompt }
+          ]
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'input_text', text: userPrompt },
+            { type: 'input_file', file_id: fileId }
+          ]
+        }
+      ],
       text: {
         format: {
           type: 'json_schema',
@@ -103,9 +168,23 @@ function textToPdf(text, filePath) {
                   type: 'object',
                   properties: {
                     message: { type: 'string' },
-                    patch: { type: 'string', pattern: '^diff --git ' }
+                    files: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          path: { type: 'string' },
+                          hunks: {
+                            type: 'array',
+                            items: { type: 'integer', minimum: 1 }
+                          }
+                        },
+                        required: ['path', 'hunks'],
+                        additionalProperties: false
+                      }
+                    }
                   },
-                  required: ['message', 'patch'],
+                  required: ['message', 'files'],
                   additionalProperties: false
                 }
               }
@@ -161,14 +240,30 @@ function textToPdf(text, filePath) {
   execSync(`git reset --hard origin/${baseBranch}`);
 
   commits.forEach((commit, index) => {
-    logBlock(`Commit ${index + 1}: ${commit.message}`, `Patch:\n${commit.patch}`);
+    let patch = '';
+    commit.files.forEach(f => {
+      const file = parsedDiff[f.path];
+      if (!file) {
+        console.error(`Unknown file in commit ${index + 1}: ${f.path}`);
+        process.exit(1);
+      }
+      patch += file.header;
+      f.hunks.forEach(h => {
+        const hunk = file.hunks[h - 1];
+        if (!hunk) {
+          console.error(`Unknown hunk ${h} in ${f.path}`);
+          process.exit(1);
+        }
+        patch += hunk;
+      });
+    });
+    logBlock(`Commit ${index + 1}: ${commit.message}`, patch);
     const patchFile = `patch_${index}.diff`;
-    const patchContent = commit.patch.endsWith('\n') ? commit.patch : `${commit.patch}\n`;
-    fs.writeFileSync(patchFile, patchContent);
+    fs.writeFileSync(patchFile, patch);
     try {
       execSync(`git apply --check ${patchFile}`);
     } catch (err) {
-      console.error(`Patch validation failed for ${patchFile}:`, patchContent);
+      console.error(`Patch validation failed for ${patchFile}`);
       throw err;
     }
     execSync(`git apply ${patchFile}`);
@@ -179,12 +274,12 @@ function textToPdf(text, filePath) {
 
   const finalDiff = execSync(`git diff origin/${baseBranch}...HEAD`, { encoding: 'utf8' });
   logBlock('Final diff after applying patches:', finalDiff);
-  if (finalDiff.trim() !== diff.trim()) {
-    logBlock('Combined patches do not match the original diff', undefined, console.error);
-    const origFile = 'original.diff';
-    const finalFile = 'final.diff';
-    fs.writeFileSync(origFile, diff);
-    fs.writeFileSync(finalFile, finalDiff);
+  if (finalDiff.trim() !== origDiff.trim()) {
+      logBlock('Combined patches do not match the original diff', undefined, console.error);
+      const origFile = 'original.diff';
+      const finalFile = 'final.diff';
+      fs.writeFileSync(origFile, origDiff);
+      fs.writeFileSync(finalFile, finalDiff);
     try {
       const comparison = execSync(`diff -u ${origFile} ${finalFile}`, { encoding: 'utf8' });
       logBlock('Difference between original and final diff:', comparison, console.error);


### PR DESCRIPTION
## Summary
- parse diff to expose numbered hunks
- request commit plan from model using hunk indexes
- assemble and apply hunks to create commits

## Testing
- `node --check scripts/split-commit.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eab83292483258bb4e9f33d77b2b9