### PR TITLE
chore: use npm install in workflow

### DIFF
--- a/.github/workflows/split-pr.yml
+++ b/.github/workflows/split-pr.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: 20
           cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm install --package-lock=false
       - name: Split last commit using GPT
         env:
           OPENAI_API_KEY_FILE: openai.key


### PR DESCRIPTION
## Summary
- avoid package-lock during CI by switching to `npm install --package-lock=false`

## Testing
- `npm test --prefix server` *(fails: Error: no test specified)*
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_6891026fe69c8325b1107adc2fe8cb99