### PR TITLE
Add unit tests for client and server

### DIFF
--- a/client/src/__tests__/api.test.js
+++ b/client/src/__tests__/api.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import apiFetch from '../api'
+
+const mockFetch = vi.fn(() => Promise.resolve({ ok: true }))
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+  global.fetch = mockFetch
+  mockFetch.mockClear()
+  localStorage.clear()
+})
+
+describe('apiFetch', () => {
+  it('attaches Authorization header when token exists', () => {
+    localStorage.setItem('access-token', 'abc123')
+    apiFetch('/test')
+    expect(mockFetch).toHaveBeenCalledWith('/test', {
+      headers: { Authorization: 'Bearer abc123' }
+    })
+  })
+
+  it('preserves existing headers and omits Authorization without token', () => {
+    apiFetch('/test', { method: 'POST', headers: { 'X-Test': '1' } })
+    expect(mockFetch).toHaveBeenCalledWith('/test', {
+      method: 'POST',
+      headers: { 'X-Test': '1' }
+    })
+  })
+})

--- a/server/__tests__/db.test.js
+++ b/server/__tests__/db.test.js
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import db from '../db.js'
+
+const login = 'vitest-user'
+
+afterEach(() => {
+  db.deleteUser(login)
+})
+
+describe('db module', () => {
+  it('adds and retrieves users', () => {
+    db.addUser(login, 'secret')
+    const users = db.getUsers()
+    expect(users.some(u => u.login === login && u.password === 'secret')).toBe(true)
+  })
+
+  it('stores and fetches user data', () => {
+    db.addUser(login, 'secret')
+    db.setData(login, 'prefs', { theme: 'dark' })
+    const data = db.getData(login, 'prefs')
+    expect(data).toEqual({ theme: 'dark' })
+  })
+})

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest",
     "start": "node index.js",
     "database-vis": "node db-visualizer.js"
   },
@@ -32,5 +32,8 @@
     "swagger-ui-express": "^5.0.1",
     "telegram-scraper": "^1.0.2",
     "undici": "^6.21.3"
+  },
+  "devDependencies": {
+    "vitest": "^1.4.0"
   }
 }


### PR DESCRIPTION
## Summary
- add API fetch unit tests for token header handling
- add DB module tests for user records and settings
- enable `vitest` testing in server package

## Testing
- `npm test --prefix server`
- `npm test --prefix client`


------
https://chatgpt.com/codex/tasks/task_e_689106ea0844832582693c8f4dde980a